### PR TITLE
Add commander and deck tracking

### DIFF
--- a/Treachery-iOS/Treachery-iOS/Helpers/ColorIdentityView.swift
+++ b/Treachery-iOS/Treachery-iOS/Helpers/ColorIdentityView.swift
@@ -1,0 +1,102 @@
+//
+//  ColorIdentityView.swift
+//  Treachery-iOS
+//
+//  Created by Luke Solomon on 3/18/26.
+//
+
+import SwiftUI
+
+/// Displays a row of MTG mana color pips for a deck's color identity.
+struct ColorIdentityPips: View {
+    let colors: [ManaColor]
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(colors, id: \.self) { color in
+                Circle()
+                    .fill(color.color)
+                    .frame(width: 14, height: 14)
+                    .overlay(
+                        Circle()
+                            .stroke(Color.mtgDivider, lineWidth: 0.5)
+                    )
+            }
+        }
+        .accessibilityLabel(colors.map(\.displayName).joined(separator: ", "))
+    }
+}
+
+/// Tappable color identity selector in WUBRG order.
+struct ColorIdentitySelector: View {
+    @Binding var selectedColors: [ManaColor]
+
+    private let allColors: [ManaColor] = [.white, .blue, .black, .red, .green, .colorless]
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(allColors, id: \.self) { color in
+                Button {
+                    toggleColor(color)
+                } label: {
+                    Circle()
+                        .fill(selectedColors.contains(color) ? color.color : color.color.opacity(0.2))
+                        .frame(width: 36, height: 36)
+                        .overlay(
+                            Circle()
+                                .stroke(
+                                    selectedColors.contains(color) ? Color.mtgGold : Color.mtgDivider,
+                                    lineWidth: selectedColors.contains(color) ? 2 : 1
+                                )
+                        )
+                        .overlay(
+                            Text(color.rawValue)
+                                .font(.caption2)
+                                .fontWeight(.bold)
+                                .foregroundStyle(selectedColors.contains(color) ? Color.mtgBackground : Color.mtgTextSecondary)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(color.displayName)
+                .accessibilityAddTraits(selectedColors.contains(color) ? .isSelected : [])
+            }
+        }
+    }
+
+    private func toggleColor(_ color: ManaColor) {
+        if let index = selectedColors.firstIndex(of: color) {
+            selectedColors.remove(at: index)
+        } else {
+            // Insert in WUBRG order
+            let order: [ManaColor] = [.white, .blue, .black, .red, .green, .colorless]
+            selectedColors.append(color)
+            selectedColors.sort { order.firstIndex(of: $0)! < order.firstIndex(of: $1)! }
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Color Identity Pips") {
+    ZStack {
+        Color.mtgBackground.ignoresSafeArea()
+        VStack(spacing: 12) {
+            ColorIdentityPips(colors: [.white, .blue])
+            ColorIdentityPips(colors: [.black, .red, .green])
+            ColorIdentityPips(colors: [.colorless])
+        }
+    }
+}
+
+#Preview("Color Identity Selector") {
+    struct PreviewWrapper: View {
+        @State private var colors: [ManaColor] = [.blue, .red]
+        var body: some View {
+            ZStack {
+                Color.mtgBackground.ignoresSafeArea()
+                ColorIdentitySelector(selectedColors: $colors)
+            }
+        }
+    }
+    return PreviewWrapper()
+}
+#endif

--- a/Treachery-iOS/Treachery-iOS/Helpers/PreviewHelpers.swift
+++ b/Treachery-iOS/Treachery-iOS/Helpers/PreviewHelpers.swift
@@ -314,6 +314,32 @@ extension PlanechaseState {
     )
 }
 
+// MARK: - Sample Decks
+
+extension Deck {
+    static let sampleDeck1 = Deck(
+        id: "deck1",
+        userId: "user1",
+        name: "Eldrazi Ramp",
+        commanderName: "Kozilek, the Great Distortion",
+        partnerCommanderName: nil,
+        colorIdentity: [.colorless],
+        createdAt: Date().addingTimeInterval(-604800),
+        lastPlayedAt: Date().addingTimeInterval(-86400)
+    )
+
+    static let sampleDeck2 = Deck(
+        id: "deck2",
+        userId: "user1",
+        name: "Simic Value",
+        commanderName: "Thrasios, Triton Hero",
+        partnerCommanderName: "Kydele, Chosen of Kruphix",
+        colorIdentity: [.blue, .green],
+        createdAt: Date().addingTimeInterval(-302400),
+        lastPlayedAt: nil
+    )
+}
+
 // MARK: - Preview NavigationPath
 
 extension Binding where Value == NavigationPath {

--- a/Treachery-iOS/Treachery-iOS/Home/AddEditDeckView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/AddEditDeckView.swift
@@ -1,0 +1,245 @@
+//
+//  AddEditDeckView.swift
+//  Treachery-iOS
+//
+//  Created by Luke Solomon on 3/18/26.
+//
+
+import SwiftUI
+
+struct AddEditDeckView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    let existingDeck: Deck?
+    var onSave: ((Deck) -> Void)?
+
+    @State private var deckName: String
+    @State private var commanderName: String
+    @State private var hasPartner: Bool
+    @State private var partnerCommanderName: String
+    @State private var colorIdentity: [ManaColor]
+    @State private var isSaving = false
+    @State private var showDeleteConfirmation = false
+    @State private var isDeleting = false
+    @State private var errorMessage: String?
+
+    private let firestoreManager = FirestoreManager()
+
+    private var isEditing: Bool { existingDeck != nil }
+
+    private var isValid: Bool {
+        !deckName.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !commanderName.trimmingCharacters(in: .whitespaces).isEmpty &&
+        (!hasPartner || !partnerCommanderName.trimmingCharacters(in: .whitespaces).isEmpty)
+    }
+
+    init(deck: Deck? = nil, onSave: ((Deck) -> Void)? = nil) {
+        self.existingDeck = deck
+        self.onSave = onSave
+        _deckName = State(initialValue: deck?.name ?? "")
+        _commanderName = State(initialValue: deck?.commanderName ?? "")
+        _hasPartner = State(initialValue: deck?.partnerCommanderName != nil)
+        _partnerCommanderName = State(initialValue: deck?.partnerCommanderName ?? "")
+        _colorIdentity = State(initialValue: deck?.colorIdentity ?? [])
+    }
+
+    var body: some View {
+        ZStack {
+            Color.mtgBackground.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Deck info card
+                    VStack(spacing: 16) {
+                        MtgSectionHeader(title: isEditing ? "Edit Deck" : "New Deck")
+
+                        OrnateDivider()
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Deck Name")
+                                .font(.caption)
+                                .foregroundStyle(Color.mtgTextSecondary)
+                            MtgTextField(
+                                placeholder: "e.g. Eldrazi Ramp",
+                                text: $deckName,
+                                autocapitalization: .words
+                            )
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Commander")
+                                .font(.caption)
+                                .foregroundStyle(Color.mtgTextSecondary)
+                            MtgTextField(
+                                placeholder: "e.g. Kozilek, the Great Distortion",
+                                text: $commanderName,
+                                autocapitalization: .words
+                            )
+                        }
+
+                        Toggle("Has Partner Commander", isOn: $hasPartner.animation(.easeInOut(duration: 0.2)))
+                            .foregroundStyle(Color.mtgTextPrimary)
+                            .tint(Color.mtgGold)
+
+                        if hasPartner {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Partner Commander")
+                                    .font(.caption)
+                                    .foregroundStyle(Color.mtgTextSecondary)
+                                MtgTextField(
+                                    placeholder: "e.g. Thrasios, Triton Hero",
+                                    text: $partnerCommanderName,
+                                    autocapitalization: .words
+                                )
+                            }
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                        }
+                    }
+                    .padding(16)
+                    .mtgCardFrame()
+
+                    // Color identity card
+                    VStack(spacing: 16) {
+                        MtgSectionHeader(title: "Color Identity")
+
+                        OrnateDivider()
+
+                        ColorIdentitySelector(selectedColors: $colorIdentity)
+                    }
+                    .padding(16)
+                    .mtgCardFrame()
+
+                    if let error = errorMessage {
+                        MtgErrorBanner(message: error)
+                    }
+
+                    // Save button
+                    Button {
+                        Task { await saveDeck() }
+                    } label: {
+                        if isSaving {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .tint(Color.mtgBackground)
+                                Text("Saving...")
+                            }
+                        } else {
+                            Text(isEditing ? "Save Changes" : "Add Deck")
+                        }
+                    }
+                    .buttonStyle(MtgPrimaryButtonStyle(isDisabled: !isValid || isSaving))
+                    .disabled(!isValid || isSaving)
+
+                    // Delete button (edit mode only)
+                    if isEditing {
+                        Button {
+                            showDeleteConfirmation = true
+                        } label: {
+                            if isDeleting {
+                                HStack(spacing: 8) {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .tint(Color.mtgError)
+                                    Text("Deleting...")
+                                }
+                            } else {
+                                Text("Delete Deck")
+                            }
+                        }
+                        .foregroundStyle(Color.mtgError)
+                        .disabled(isDeleting)
+                        .confirmationDialog(
+                            "Delete this deck?",
+                            isPresented: $showDeleteConfirmation,
+                            titleVisibility: .visible
+                        ) {
+                            Button("Delete", role: .destructive) {
+                                Task { await deleteDeck() }
+                            }
+                            Button("Cancel", role: .cancel) {}
+                        } message: {
+                            Text("This will permanently remove \"\(deckName)\" and its history association. This cannot be undone.")
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle(isEditing ? "Edit Deck" : "New Deck")
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    // MARK: - Actions
+
+    private func saveDeck() async {
+        guard let userId = authViewModel.currentUserId else { return }
+        guard isValid else { return }
+        isSaving = true
+        errorMessage = nil
+
+        let deck = Deck(
+            id: existingDeck?.id ?? UUID().uuidString,
+            userId: userId,
+            name: deckName.trimmingCharacters(in: .whitespaces),
+            commanderName: commanderName.trimmingCharacters(in: .whitespaces),
+            partnerCommanderName: hasPartner ? partnerCommanderName.trimmingCharacters(in: .whitespaces) : nil,
+            colorIdentity: colorIdentity,
+            createdAt: existingDeck?.createdAt ?? Date(),
+            lastPlayedAt: existingDeck?.lastPlayedAt
+        )
+
+        do {
+            if isEditing {
+                try await firestoreManager.updateDeck(deck)
+            } else {
+                try await firestoreManager.createDeck(deck)
+            }
+            onSave?(deck)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSaving = false
+    }
+
+    private func deleteDeck() async {
+        guard let deck = existingDeck else { return }
+        isDeleting = true
+        errorMessage = nil
+
+        do {
+            try await firestoreManager.deleteDeck(id: deck.id, userId: deck.userId)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isDeleting = false
+    }
+}
+
+#if DEBUG
+#Preview("Add Deck") {
+    NavigationStack {
+        AddEditDeckView()
+    }
+    .environmentObject(AuthViewModel())
+}
+
+#Preview("Edit Deck") {
+    NavigationStack {
+        AddEditDeckView(deck: Deck(
+            id: "deck1",
+            userId: "user1",
+            name: "Eldrazi Ramp",
+            commanderName: "Kozilek, the Great Distortion",
+            partnerCommanderName: nil,
+            colorIdentity: [.colorless],
+            createdAt: Date(),
+            lastPlayedAt: Date()
+        ))
+    }
+    .environmentObject(AuthViewModel())
+}
+#endif

--- a/Treachery-iOS/Treachery-iOS/Home/DeckListView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/DeckListView.swift
@@ -1,0 +1,266 @@
+//
+//  DeckListView.swift
+//  Treachery-iOS
+//
+//  Created by Luke Solomon on 3/18/26.
+//
+
+import SwiftUI
+
+struct DeckListView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    @State private var decks: [Deck] = []
+    @State private var deckStats: [String: DeckStatLine] = [:]
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let firestoreManager = FirestoreManager()
+
+    var body: some View {
+        ZStack {
+            Color.mtgBackground.ignoresSafeArea()
+
+            if isLoading {
+                ProgressView("Loading decks...")
+                    .tint(Color.mtgGold)
+                    .foregroundStyle(Color.mtgTextSecondary)
+            } else if decks.isEmpty {
+                emptyState
+            } else {
+                deckList
+            }
+        }
+        .navigationTitle("My Decks")
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    AddEditDeckView(onSave: { _ in
+                        Task { await loadData() }
+                    })
+                } label: {
+                    Image(systemName: "plus")
+                        .foregroundStyle(Color.mtgGold)
+                }
+                .accessibilityLabel("Add new deck")
+            }
+        }
+        .task {
+            await loadData()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "rectangle.stack")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.mtgGold.opacity(0.5))
+
+            Text("No Decks Yet")
+                .font(.system(.title2, design: .serif))
+                .fontWeight(.bold)
+                .foregroundStyle(Color.mtgTextPrimary)
+
+            Text("Add your first deck to track your commanders and game stats.")
+                .font(.subheadline)
+                .foregroundStyle(Color.mtgTextSecondary)
+                .multilineTextAlignment(.center)
+
+            NavigationLink {
+                AddEditDeckView(onSave: { _ in
+                    Task { await loadData() }
+                })
+            } label: {
+                Text("Add Deck")
+            }
+            .buttonStyle(MtgPrimaryButtonStyle())
+            .padding(.horizontal, 40)
+            .padding(.top, 8)
+        }
+        .padding()
+    }
+
+    private var deckList: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                if let error = errorMessage {
+                    MtgErrorBanner(message: error)
+                        .padding(.horizontal)
+                }
+
+                ForEach(decks) { deck in
+                    NavigationLink {
+                        AddEditDeckView(deck: deck, onSave: { _ in
+                            Task { await loadData() }
+                        })
+                    } label: {
+                        DeckRow(deck: deck, stats: deckStats[deck.id])
+                    }
+                    .buttonStyle(.plain)
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            Task { await deleteDeck(deck) }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Data
+
+    private func loadData() async {
+        guard let userId = authViewModel.currentUserId else { return }
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            decks = try await firestoreManager.getDecks(forUserId: userId)
+
+            // Compute stats from game history
+            let games = try await firestoreManager.getFinishedGames(forUserId: userId)
+            var stats: [String: DeckStatLine] = [:]
+
+            for game in games {
+                if let players = try? await firestoreManager.getPlayers(gameId: game.id),
+                   let myPlayer = players.first(where: { $0.userId == userId }),
+                   let deckId = myPlayer.deckId {
+
+                    var stat = stats[deckId] ?? DeckStatLine()
+                    stat.gamesPlayed += 1
+
+                    if let winTeamString = game.winningTeam,
+                       let winRole = Role(rawValue: winTeamString),
+                       let myRole = myPlayer.role {
+                        let didWin: Bool
+                        if winRole == .leader {
+                            didWin = myRole == .leader || myRole == .guardian
+                        } else {
+                            didWin = myRole == winRole
+                        }
+                        if didWin {
+                            stat.wins += 1
+                        } else {
+                            stat.losses += 1
+                        }
+                    }
+
+                    stats[deckId] = stat
+                }
+            }
+            deckStats = stats
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func deleteDeck(_ deck: Deck) async {
+        do {
+            try await firestoreManager.deleteDeck(id: deck.id, userId: deck.userId)
+            decks.removeAll { $0.id == deck.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Deck Row
+
+private struct DeckRow: View {
+    let deck: Deck
+    let stats: DeckStatLine?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(deck.name)
+                        .font(.system(.headline, design: .serif))
+                        .foregroundStyle(Color.mtgTextPrimary)
+
+                    Text(deck.commanderDisplayName)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.mtgGold)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(Color.mtgTextSecondary)
+            }
+
+            HStack {
+                if !deck.colorIdentity.isEmpty {
+                    ColorIdentityPips(colors: deck.colorIdentity)
+                }
+
+                Spacer()
+
+                if let stats = stats {
+                    HStack(spacing: 12) {
+                        StatPill(label: "G", value: "\(stats.gamesPlayed)", color: .mtgTextPrimary)
+                        StatPill(label: "W", value: "\(stats.wins)", color: .mtgSuccess)
+                        StatPill(label: "L", value: "\(stats.losses)", color: .mtgError)
+                        if stats.gamesPlayed > 0 {
+                            StatPill(label: "%", value: "\(stats.winPercent)", color: .mtgGuardian)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .mtgCardFrame()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(deck.name), commander \(deck.commanderDisplayName)")
+    }
+}
+
+// MARK: - Stat Pill
+
+private struct StatPill: View {
+    let label: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(Color.mtgTextSecondary)
+            Text(value)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - Deck Stat
+
+struct DeckStatLine {
+    var gamesPlayed: Int = 0
+    var wins: Int = 0
+    var losses: Int = 0
+
+    var winPercent: Int {
+        guard gamesPlayed > 0 else { return 0 }
+        return Int(Double(wins) / Double(gamesPlayed) * 100)
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        DeckListView()
+    }
+    .environmentObject(AuthViewModel())
+}
+#endif

--- a/Treachery-iOS/Treachery-iOS/Home/DeckPickerView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/DeckPickerView.swift
@@ -1,0 +1,152 @@
+//
+//  DeckPickerView.swift
+//  Treachery-iOS
+//
+//  Created by Luke Solomon on 3/18/26.
+//
+
+import SwiftUI
+
+struct DeckPickerView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    let onSelect: (Deck?) -> Void
+
+    @State private var decks: [Deck] = []
+    @State private var isLoading = true
+    @State private var showAddDeck = false
+    @State private var errorMessage: String?
+
+    private let firestoreManager = FirestoreManager()
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.mtgBackground.ignoresSafeArea()
+
+                if isLoading {
+                    ProgressView("Loading decks...")
+                        .tint(Color.mtgGold)
+                        .foregroundStyle(Color.mtgTextSecondary)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            // No deck option
+                            Button {
+                                onSelect(nil)
+                                dismiss()
+                            } label: {
+                                HStack {
+                                    Image(systemName: "xmark.circle")
+                                        .foregroundStyle(Color.mtgTextSecondary)
+                                    Text("No Deck")
+                                        .foregroundStyle(Color.mtgTextPrimary)
+                                    Spacer()
+                                }
+                                .padding(16)
+                            }
+                            .mtgCardFrame(borderColor: Color.mtgDivider)
+                            .padding(.horizontal)
+                            .padding(.top)
+
+                            if let error = errorMessage {
+                                MtgErrorBanner(message: error)
+                                    .padding()
+                            }
+
+                            // Deck list
+                            ForEach(decks) { deck in
+                                Button {
+                                    onSelect(deck)
+                                    dismiss()
+                                } label: {
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(deck.name)
+                                                .font(.system(.headline, design: .serif))
+                                                .foregroundStyle(Color.mtgTextPrimary)
+                                            Text(deck.commanderDisplayName)
+                                                .font(.caption)
+                                                .foregroundStyle(Color.mtgGold)
+                                        }
+
+                                        Spacer()
+
+                                        if !deck.colorIdentity.isEmpty {
+                                            ColorIdentityPips(colors: deck.colorIdentity)
+                                        }
+                                    }
+                                    .padding(16)
+                                }
+                                .mtgCardFrame()
+                                .padding(.horizontal)
+                                .padding(.top, 8)
+                            }
+
+                            // Add new deck
+                            Button {
+                                showAddDeck = true
+                            } label: {
+                                HStack {
+                                    Image(systemName: "plus.circle.fill")
+                                        .foregroundStyle(Color.mtgGold)
+                                    Text("Add New Deck")
+                                        .foregroundStyle(Color.mtgGold)
+                                    Spacer()
+                                }
+                                .padding(16)
+                            }
+                            .mtgCardFrame(borderColor: Color.mtgGold.opacity(0.5))
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+                            .padding(.bottom)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Select Deck")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundStyle(Color.mtgGold)
+                }
+            }
+            .sheet(isPresented: $showAddDeck) {
+                NavigationStack {
+                    AddEditDeckView(onSave: { newDeck in
+                        onSelect(newDeck)
+                        dismiss()
+                    })
+                }
+            }
+            .task {
+                await loadDecks()
+            }
+        }
+    }
+
+    private func loadDecks() async {
+        guard let userId = authViewModel.currentUserId else { return }
+        isLoading = true
+        do {
+            decks = try await firestoreManager.getDecks(forUserId: userId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}
+
+#if DEBUG
+#Preview {
+    DeckPickerView { deck in
+        print("Selected: \(deck?.name ?? "None")")
+    }
+    .environmentObject(AuthViewModel())
+}
+#endif

--- a/Treachery-iOS/Treachery-iOS/Home/GameBoardView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/GameBoardView.swift
@@ -17,6 +17,7 @@ struct GameBoardView: View {
     @State private var showForfeitConfirmation = false
     @State private var showGameUnavailableAlert = false
     @State private var showEndGameConfirmation = false
+    @State private var showDeckPicker = false
     @State private var inspectedPlayer: Player?
 
     init(gameId: String, navigationPath: Binding<NavigationPath>) {
@@ -156,9 +157,11 @@ struct GameBoardView: View {
 
                             VStack(spacing: 0) {
                                 ForEach(viewModel.players) { player in
-                                    PlayerRow(player: player, viewModel: viewModel) { tappedPlayer in
+                                    PlayerRow(player: player, viewModel: viewModel, onViewCard: { tappedPlayer in
                                         inspectedPlayer = tappedPlayer
-                                    }
+                                    }, onChangeDeck: player.userId == viewModel.currentUserId ? {
+                                        showDeckPicker = true
+                                    } : nil)
                                     .padding(.horizontal, 16)
                                     .padding(.vertical, 8)
 
@@ -323,6 +326,13 @@ struct GameBoardView: View {
         )) {
             if let options = viewModel.tunnelOptions {
                 InterplanarTunnelPicker(options: options, viewModel: viewModel)
+            }
+        }
+        .sheet(isPresented: $showDeckPicker) {
+            DeckPickerView { deck in
+                Task {
+                    await viewModel.selectDeck(deck)
+                }
             }
         }
     }
@@ -497,6 +507,7 @@ private struct PlayerRow: View {
     let player: Player
     @ObservedObject var viewModel: GameBoardViewModel
     var onViewCard: ((Player) -> Void)?
+    var onChangeDeck: (() -> Void)?
 
     private var isCurrentUser: Bool {
         player.userId == viewModel.currentUserId
@@ -535,6 +546,42 @@ private struct PlayerRow: View {
                             .foregroundStyle(Color.mtgError)
                             .font(.caption)
                     }
+                }
+
+                // Commander name
+                if let commander = player.commanderName, !commander.isEmpty {
+                    if isCurrentUser {
+                        Button {
+                            onChangeDeck?()
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text(commander)
+                                    .font(.caption2)
+                                    .foregroundStyle(Color.mtgGold)
+                                Image(systemName: "pencil")
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(Color.mtgGold)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        Text(commander)
+                            .font(.caption2)
+                            .foregroundStyle(Color.mtgTextSecondary)
+                    }
+                } else if isCurrentUser {
+                    Button {
+                        onChangeDeck?()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "rectangle.stack")
+                                .font(.system(size: 8))
+                            Text("Select Deck")
+                                .font(.caption2)
+                        }
+                        .foregroundStyle(Color.mtgGold.opacity(0.7))
+                    }
+                    .buttonStyle(.plain)
                 }
 
                 // Role visibility

--- a/Treachery-iOS/Treachery-iOS/Home/GameBoardViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/GameBoardViewModel.swift
@@ -318,6 +318,23 @@ final class GameBoardViewModel: ObservableObject {
         isPending = false
     }
 
+    // MARK: - Deck Selection
+
+    func selectDeck(_ deck: Deck?) async {
+        guard let player = currentPlayer else { return }
+        errorMessage = nil
+        do {
+            try await firestoreManager.updatePlayerDeck(
+                playerId: player.id,
+                gameId: gameId,
+                deckId: deck?.id,
+                commanderName: deck?.commanderDisplayName
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     // MARK: - Helpers
 
     func identityCard(for player: Player) -> IdentityCard? {

--- a/Treachery-iOS/Treachery-iOS/Home/GameOverView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/GameOverView.swift
@@ -70,9 +70,16 @@ struct GameOverView: View {
                                         .fill(player.role?.color ?? .gray)
                                         .frame(width: 12, height: 12)
 
-                                    Text(player.displayName)
-                                        .fontWeight(.medium)
-                                        .foregroundStyle(Color.mtgTextPrimary)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(player.displayName)
+                                            .fontWeight(.medium)
+                                            .foregroundStyle(Color.mtgTextPrimary)
+                                        if let commander = player.commanderName, !commander.isEmpty {
+                                            Text(commander)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color.mtgGold)
+                                        }
+                                    }
 
                                     Spacer()
 
@@ -144,9 +151,16 @@ struct GameOverView: View {
                         VStack(spacing: 0) {
                             ForEach(viewModel.players) { player in
                                 HStack {
-                                    Text(player.displayName)
-                                        .fontWeight(.medium)
-                                        .foregroundStyle(Color.mtgTextPrimary)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(player.displayName)
+                                            .fontWeight(.medium)
+                                            .foregroundStyle(Color.mtgTextPrimary)
+                                        if let commander = player.commanderName, !commander.isEmpty {
+                                            Text(commander)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color.mtgGold)
+                                        }
+                                    }
 
                                     Spacer()
 
@@ -191,6 +205,25 @@ struct GameOverView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             viewModel.currentUserId = authViewModel.currentUserId
+        }
+        .task {
+            await updateDeckLastPlayed()
+        }
+    }
+
+    private func updateDeckLastPlayed() async {
+        guard let userId = authViewModel.currentUserId else { return }
+        // Wait for players to load
+        while viewModel.players.isEmpty {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        guard let myPlayer = viewModel.players.first(where: { $0.userId == userId }),
+              let deckId = myPlayer.deckId else { return }
+
+        let firestoreManager = FirestoreManager()
+        if var deck = try? await firestoreManager.getDeck(id: deckId, userId: userId) {
+            deck.lastPlayedAt = Date()
+            try? await firestoreManager.updateDeck(deck)
         }
     }
 }

--- a/Treachery-iOS/Treachery-iOS/Home/HomeView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/HomeView.swift
@@ -20,6 +20,8 @@ enum AppDestination: Hashable {
     case profile
     case friends
     case gameHistory
+    case decks
+    case addEditDeck(Deck?)
 }
 
 struct HomeView: View {
@@ -144,6 +146,17 @@ struct HomeView: View {
                         }
                         .accessibilityLabel("Game history")
 
+                        NavigationLink(value: AppDestination.decks) {
+                            VStack(spacing: 4) {
+                                Image(systemName: "rectangle.stack.fill")
+                                    .font(.title3)
+                                Text("Decks")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(Color.mtgTextSecondary)
+                        }
+                        .accessibilityLabel("My decks")
+
                         NavigationLink(value: AppDestination.friends) {
                             VStack(spacing: 4) {
                                 Image(systemName: "person.2.fill")
@@ -217,6 +230,10 @@ struct HomeView: View {
                     FriendsListView()
                 case .gameHistory:
                     GameHistoryView()
+                case .decks:
+                    DeckListView()
+                case .addEditDeck(let deck):
+                    AddEditDeckView(deck: deck)
                 }
             }
         }

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
@@ -13,6 +13,7 @@ struct LobbyView: View {
     @Binding var navigationPath: NavigationPath
     @State private var showHostLeftAlert = false
     @State private var showShareSheet = false
+    @State private var showDeckPicker = false
     @State private var isLeaving = false
 
     init(gameId: String, isHost: Bool, navigationPath: Binding<NavigationPath>) {
@@ -122,10 +123,35 @@ struct LobbyView: View {
                                 VStack(spacing: 0) {
                                     ForEach(viewModel.players) { player in
                                         HStack {
-                                            Text(player.displayName)
-                                                .fontWeight(player.userId == viewModel.game?.hostId ? .semibold : .regular)
-                                                .foregroundStyle(Color.mtgTextPrimary)
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(player.displayName)
+                                                    .fontWeight(player.userId == viewModel.game?.hostId ? .semibold : .regular)
+                                                    .foregroundStyle(Color.mtgTextPrimary)
+                                                if let commander = player.commanderName, !commander.isEmpty {
+                                                    Text(commander)
+                                                        .font(.caption)
+                                                        .foregroundStyle(Color.mtgGold)
+                                                }
+                                            }
                                             Spacer()
+                                            if player.userId == authViewModel.currentUserId {
+                                                Button {
+                                                    showDeckPicker = true
+                                                } label: {
+                                                    HStack(spacing: 4) {
+                                                        Image(systemName: "rectangle.stack")
+                                                            .font(.caption)
+                                                        Text(player.commanderName != nil ? "Change" : "Deck")
+                                                            .font(.caption)
+                                                    }
+                                                    .foregroundStyle(Color.mtgGold)
+                                                    .padding(.horizontal, 8)
+                                                    .padding(.vertical, 4)
+                                                    .background(Color.mtgGold.opacity(0.15))
+                                                    .clipShape(Capsule())
+                                                }
+                                                .buttonStyle(.plain)
+                                            }
                                             if player.userId == viewModel.game?.hostId {
                                                 Text("Host")
                                                     .font(.caption)
@@ -251,6 +277,15 @@ struct LobbyView: View {
         .sheet(isPresented: $showShareSheet) {
             if let code = viewModel.game?.code {
                 ShareSheet(items: ["Join my Treachery game! Code: \(code)"])
+            }
+        }
+        .sheet(isPresented: $showDeckPicker) {
+            DeckPickerView { deck in
+                if let userId = authViewModel.currentUserId {
+                    Task {
+                        await viewModel.selectDeck(deck, forUserId: userId)
+                    }
+                }
             }
         }
     }

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
@@ -93,6 +93,21 @@ final class LobbyViewModel: ObservableObject {
         isStartingGame = false
     }
 
+    func selectDeck(_ deck: Deck?, forUserId userId: String) async {
+        guard let player = players.first(where: { $0.userId == userId }) else { return }
+        errorMessage = nil
+        do {
+            try await firestoreManager.updatePlayerDeck(
+                playerId: player.id,
+                gameId: gameId,
+                deckId: deck?.id,
+                commanderName: deck?.commanderDisplayName
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func leaveGame(userId: String) async {
         errorMessage = nil
         // Stop listeners before leaving to prevent race conditions

--- a/Treachery-iOS/Treachery-iOS/Home/ProfileView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/ProfileView.swift
@@ -136,6 +136,23 @@ struct ProfileView: View {
                     }
                     .mtgCardFrame()
 
+                    // Decks card
+                    NavigationLink(value: AppDestination.decks) {
+                        HStack {
+                            Text("My Decks")
+                                .foregroundStyle(Color.mtgTextPrimary)
+                            Spacer()
+                            Image(systemName: "rectangle.stack.fill")
+                                .font(.caption)
+                                .foregroundStyle(Color.mtgTextSecondary)
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(Color.mtgTextSecondary)
+                        }
+                        .padding(16)
+                    }
+                    .mtgCardFrame()
+
                     // Friends card
                     if let user = user {
                         NavigationLink {

--- a/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
+++ b/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
@@ -189,6 +189,54 @@ final class FirestoreManager {
         }
     }
 
+    // MARK: - Decks
+
+    private func decksCollection(userId: String) -> CollectionReference {
+        usersCollection.document(userId).collection("decks")
+    }
+
+    func createDeck(_ deck: Deck) async throws {
+        try decksCollection(userId: deck.userId).document(deck.id).setData(from: deck)
+    }
+
+    func getDecks(forUserId userId: String) async throws -> [Deck] {
+        let snapshot = try await decksCollection(userId: userId)
+            .order(by: "created_at", descending: true)
+            .getDocuments()
+        return snapshot.documents.compactMap { try? $0.data(as: Deck.self) }
+    }
+
+    func getDeck(id: String, userId: String) async throws -> Deck? {
+        let snapshot = try await decksCollection(userId: userId).document(id).getDocument()
+        guard snapshot.exists else { return nil }
+        return try snapshot.data(as: Deck.self)
+    }
+
+    func updateDeck(_ deck: Deck) async throws {
+        try decksCollection(userId: deck.userId).document(deck.id).setData(from: deck, merge: true)
+    }
+
+    func deleteDeck(id: String, userId: String) async throws {
+        try await decksCollection(userId: userId).document(id).delete()
+    }
+
+    // MARK: - Player Deck Selection
+
+    func updatePlayerDeck(playerId: String, gameId: String, deckId: String?, commanderName: String?) async throws {
+        var data: [String: Any] = [:]
+        if let deckId = deckId {
+            data["deck_id"] = deckId
+        } else {
+            data["deck_id"] = FieldValue.delete()
+        }
+        if let commanderName = commanderName {
+            data["commander_name"] = commanderName
+        } else {
+            data["commander_name"] = FieldValue.delete()
+        }
+        try await playersCollection(gameId: gameId).document(playerId).updateData(data)
+    }
+
     // MARK: - Players
 
     func addPlayer(_ player: Player, toGame gameId: String) async throws {

--- a/Treachery-iOS/Treachery-iOS/Models/Deck.swift
+++ b/Treachery-iOS/Treachery-iOS/Models/Deck.swift
@@ -1,0 +1,69 @@
+//
+//  Deck.swift
+//  Treachery-iOS
+//
+//  Created by Luke Solomon on 3/18/26.
+//
+
+import Foundation
+import SwiftUI
+
+enum ManaColor: String, Codable, CaseIterable, Hashable {
+    case white = "W"
+    case blue = "U"
+    case black = "B"
+    case red = "R"
+    case green = "G"
+    case colorless = "C"
+
+    var displayName: String {
+        switch self {
+        case .white: return "White"
+        case .blue: return "Blue"
+        case .black: return "Black"
+        case .red: return "Red"
+        case .green: return "Green"
+        case .colorless: return "Colorless"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .white: return Color(red: 0.96, green: 0.94, blue: 0.86)
+        case .blue: return Color(red: 0.30, green: 0.55, blue: 0.79)
+        case .black: return Color(red: 0.55, green: 0.47, blue: 0.58)
+        case .red: return Color(red: 0.79, green: 0.30, blue: 0.30)
+        case .green: return Color(red: 0.24, green: 0.66, blue: 0.36)
+        case .colorless: return Color(red: 0.65, green: 0.65, blue: 0.65)
+        }
+    }
+}
+
+struct Deck: Codable, Identifiable, Hashable {
+    let id: String
+    let userId: String
+    var name: String
+    var commanderName: String
+    var partnerCommanderName: String?
+    var colorIdentity: [ManaColor]
+    let createdAt: Date
+    var lastPlayedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case name
+        case commanderName = "commander_name"
+        case partnerCommanderName = "partner_commander_name"
+        case colorIdentity = "color_identity"
+        case createdAt = "created_at"
+        case lastPlayedAt = "last_played_at"
+    }
+
+    var commanderDisplayName: String {
+        if let partner = partnerCommanderName, !partner.isEmpty {
+            return "\(commanderName) & \(partner)"
+        }
+        return commanderName
+    }
+}

--- a/Treachery-iOS/Treachery-iOS/Models/Player.swift
+++ b/Treachery-iOS/Treachery-iOS/Models/Player.swift
@@ -18,6 +18,8 @@ struct Player: Codable, Identifiable {
     var isEliminated: Bool
     var isUnveiled: Bool
     let joinedAt: Date
+    var deckId: String? = nil
+    var commanderName: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -30,5 +32,7 @@ struct Player: Codable, Identifiable {
         case isEliminated = "is_eliminated"
         case isUnveiled = "is_unveiled"
         case joinedAt = "joined_at"
+        case deckId = "deck_id"
+        case commanderName = "commander_name"
     }
 }


### PR DESCRIPTION
## Summary
- Adds first-class deck management: create, edit, and delete decks with commander names, partner commanders, and MTG color identity (WUBRG)
- Deck selection available in both the game lobby and during active gameplay via a picker sheet
- Commander names displayed in lobby player list, game board player rows, and game-over results
- Per-deck win/loss stats computed from game history, shown in the deck list view
- Decks stored as Firestore subcollection (`users/{userId}/decks/{deckId}`) for scalability

## New files
- `Models/Deck.swift` — Deck model + ManaColor enum
- `Helpers/ColorIdentityView.swift` — Color identity display pips + selector
- `Home/AddEditDeckView.swift` — Create/edit deck form
- `Home/DeckListView.swift` — Deck collection with stats
- `Home/DeckPickerView.swift` — In-game deck selection sheet

## Modified files
- `Player.swift` — Added optional `deckId` and `commanderName` fields (backward compatible)
- `FirestoreManager.swift` — Deck CRUD + player deck update
- `HomeView.swift` — "Decks" tab in bottom nav
- `ProfileView.swift` — "My Decks" navigation link
- `LobbyView/ViewModel` — Deck selection + commander display
- `GameBoardView/ViewModel` — Deck selection + commander display in player rows
- `GameOverView` — Commander display + deck lastPlayedAt update

## Test plan
- [ ] Create a deck with commander, partner, and color identity → verify Firestore document
- [ ] Edit and delete decks → verify updates/removals
- [ ] In lobby: select a deck → verify commander appears in player list
- [ ] On game board: change deck mid-game → verify real-time update
- [ ] Finish a game with a deck selected → verify deck stats update
- [ ] Load existing games without deck data → verify no crashes (backward compat)
- [ ] New files need to be added to Xcode project navigator manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)