### PR TITLE
Fix phone auth on real devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ Treachery-iOS/Treachery-iOS/Support Files/GoogleService-Info.plist
 
 # Firebase
 .firebase/
+
+# APNs auth keys
+*.p8

--- a/Treachery-iOS/Treachery-iOS/Treachery_iOSApp.swift
+++ b/Treachery-iOS/Treachery-iOS/Treachery_iOSApp.swift
@@ -32,7 +32,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, UNUserNot
     ) -> Bool {
         FirebaseApp.configure()
 
-        #if DEBUG
+        #if targetEnvironment(simulator)
         Auth.auth().settings?.isAppVerificationDisabledForTesting = true
         #endif
 


### PR DESCRIPTION
## Summary
- Changed `isAppVerificationDisabledForTesting` from `#if DEBUG` to `#if targetEnvironment(simulator)` so phone auth works on real devices while still allowing test phone numbers on the simulator
- Added `*.p8` to `.gitignore` to prevent APNs authentication keys from being committed

## Test plan
- [ ] Verify phone auth works on a real device
- [ ] Verify test phone numbers work on the simulator
- [ ] Confirm no .p8 files are tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)