### PR TITLE
Remove player count from game creation, fix web rejoin

### DIFF
--- a/Treachery-iOS/Treachery-iOS.xcodeproj/xcshareddata/xcschemes/Treachery-iOS.xcscheme
+++ b/Treachery-iOS/Treachery-iOS.xcodeproj/xcshareddata/xcschemes/Treachery-iOS.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3AA07E62C90A6DD0093EF53"
+               BuildableName = "Treachery-iOS.app"
+               BlueprintName = "Treachery-iOS"
+               ReferencedContainer = "container:Treachery-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3AA07F92C90A6DF0093EF53"
+               BuildableName = "Treachery-iOSTests.xctest"
+               BlueprintName = "Treachery-iOSTests"
+               ReferencedContainer = "container:Treachery-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3AA08032C90A6DF0093EF53"
+               BuildableName = "Treachery-iOSUITests.xctest"
+               BlueprintName = "Treachery-iOSUITests"
+               ReferencedContainer = "container:Treachery-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3AA07E62C90A6DD0093EF53"
+            BuildableName = "Treachery-iOS.app"
+            BlueprintName = "Treachery-iOS"
+            ReferencedContainer = "container:Treachery-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3AA07E62C90A6DD0093EF53"
+            BuildableName = "Treachery-iOS.app"
+            BlueprintName = "Treachery-iOS"
+            ReferencedContainer = "container:Treachery-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Treachery-iOS/Treachery-iOS/Home/CreateGameView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/CreateGameView.swift
@@ -13,19 +13,15 @@ struct CreateGameView: View {
 
     @State private var gameMode: GameMode = .treachery
     @State private var useOwnDeck = false
-    @State private var maxPlayers = Role.minimumPlayerCount
     @State private var startingLife = 40
     @State private var isCreating = false
     @State private var errorMessage: String?
 
     private let firestoreManager = FirestoreManager()
 
-    private var playerRange: ClosedRange<Int> {
-        if gameMode.includesTreachery {
-            return Role.minimumPlayerCount...8
-        } else {
-            return 1...12
-        }
+    /// Max players is determined by game mode — no user input needed.
+    private var maxPlayers: Int {
+        gameMode.includesTreachery ? 8 : 12
     }
 
     var body: some View {
@@ -78,37 +74,12 @@ struct CreateGameView: View {
 
                         OrnateDivider()
 
-                        Stepper("Players: \(maxPlayers)", value: $maxPlayers, in: playerRange)
-                            .foregroundStyle(Color.mtgTextPrimary)
-                            .accessibilityValue("\(maxPlayers) players")
-
                         Stepper("Starting Life: \(startingLife)", value: $startingLife, in: 20...60, step: 5)
                             .foregroundStyle(Color.mtgTextPrimary)
                             .accessibilityValue("\(startingLife) life")
                     }
                     .padding(16)
                     .mtgCardFrame()
-
-                    // Role distribution preview (only for treachery modes)
-                    if gameMode.includesTreachery {
-                        VStack(spacing: 16) {
-                            MtgSectionHeader(title: "Role Distribution")
-
-                            OrnateDivider()
-
-                            let dist = Role.distribution(forPlayerCount: maxPlayers)
-                            HStack(spacing: 12) {
-                                RoleBadge(count: dist.leaders, role: .leader)
-                                RoleBadge(count: dist.guardians, role: .guardian)
-                                RoleBadge(count: dist.assassins, role: .assassin)
-                                RoleBadge(count: dist.traitors, role: .traitor)
-                            }
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel("Role distribution: \(dist.leaders) leaders, \(dist.guardians) guardians, \(dist.assassins) assassins, \(dist.traitors) traitors")
-                        }
-                        .padding(16)
-                        .mtgCardFrame()
-                    }
 
                     if let error = errorMessage {
                         MtgErrorBanner(message: error)
@@ -139,12 +110,6 @@ struct CreateGameView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .onAppear { AnalyticsService.trackScreen("CreateGame") }
         .onChange(of: gameMode) { _, _ in
-            // Clamp maxPlayers to valid range when switching modes
-            if maxPlayers < playerRange.lowerBound {
-                maxPlayers = playerRange.lowerBound
-            } else if maxPlayers > playerRange.upperBound {
-                maxPlayers = playerRange.upperBound
-            }
             // Reset own deck toggle when planechase is disabled
             if !gameMode.includesPlanechase {
                 useOwnDeck = false
@@ -198,8 +163,7 @@ struct CreateGameView: View {
             try await firestoreManager.addPlayer(player, toGame: game.id)
 
             AnalyticsService.trackEvent("create_game", params: [
-                "game_mode": gameMode.rawValue,
-                "max_players": maxPlayers
+                "game_mode": gameMode.rawValue
             ])
             navigationPath.append(AppDestination.lobby(gameId: game.id, isHost: true))
         } catch {
@@ -219,35 +183,6 @@ struct CreateGameView: View {
             }
         }
         throw GameError.codeGenerationFailed
-    }
-}
-
-// MARK: - Role Badge
-
-private struct RoleBadge: View {
-    let count: Int
-    let role: Role
-
-    var body: some View {
-        VStack(spacing: 4) {
-            Text("\(count)")
-                .font(.title2)
-                .fontWeight(.bold)
-                .foregroundStyle(role.color)
-            Text(role.displayName)
-                .font(.caption2)
-                .foregroundStyle(Color.mtgTextSecondary)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 10)
-        .background(Color.mtgCardElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(role.color.opacity(0.3), lineWidth: 1)
-        )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(count) \(role.displayName)")
     }
 }
 

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
@@ -161,7 +161,7 @@ struct LobbyView: View {
     private var playerListSection: some View {
         ScrollView {
             VStack(spacing: 0) {
-                MtgSectionHeader(title: "Players (\(viewModel.players.count)/\(viewModel.game?.maxPlayers ?? 0))")
+                MtgSectionHeader(title: "Players (\(viewModel.players.count))")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
                     .padding(.bottom, 8)

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
@@ -34,7 +34,7 @@ final class LobbyViewModel: ObservableObject {
     var canStartGame: Bool {
         guard let game = game else { return false }
         let minPlayers = game.gameMode.includesTreachery ? Role.minimumPlayerCount : 1
-        return isHost && players.count >= minPlayers && players.count <= game.maxPlayers
+        return isHost && players.count >= minPlayers
     }
 
     var minimumPlayerCount: Int {

--- a/Treachery/app/(app)/create-game.tsx
+++ b/Treachery/app/(app)/create-game.tsx
@@ -11,10 +11,9 @@ import {
 import { useRouter } from 'expo-router';
 import { Timestamp } from 'firebase/firestore';
 import { useAuth } from '@/hooks/useAuth';
-import { RoleBadge } from '@/components/RoleBadge';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import * as firestoreService from '@/services/firestore';
-import { getRoleDistribution, MINIMUM_PLAYER_COUNT, CODE_CHARACTERS } from '@/constants/roles';
+import { CODE_CHARACTERS } from '@/constants/roles';
 import { Game, GameMode, Player } from '@/models/types';
 import { trackEvent } from '@/services/analytics';
 import { colors, spacing, fontSize } from '@/constants/theme';
@@ -47,26 +46,18 @@ export default function CreateGameScreen() {
   const { currentUserId } = useAuth();
   const [gameMode, setGameMode] = useState<GameMode>('treachery');
   const [useOwnDeck, setUseOwnDeck] = useState(false);
-  const [maxPlayers, setMaxPlayers] = useState(MINIMUM_PLAYER_COUNT);
   const [startingLife, setStartingLife] = useState(40);
   const [isCreating, setIsCreating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const hasTreachery = includesTreachery(gameMode);
   const hasPlanechase = includesPlanechase(gameMode);
-  const minPlayers = hasTreachery ? MINIMUM_PLAYER_COUNT : 1;
-  const maxPlayerLimit = hasTreachery ? 8 : 12;
 
-  const dist = getRoleDistribution(maxPlayers);
+  // Max players is determined by game mode — no user input needed.
+  const maxPlayers = hasTreachery ? 8 : 12;
 
   const handleModeChange = (mode: GameMode) => {
     setGameMode(mode);
-    const newHasTreachery = includesTreachery(mode);
-    const newMin = newHasTreachery ? MINIMUM_PLAYER_COUNT : 1;
-    const newMax = newHasTreachery ? 8 : 12;
-    // Clamp player count to new valid range
-    if (maxPlayers < newMin) setMaxPlayers(newMin);
-    if (maxPlayers > newMax) setMaxPlayers(newMax);
     // Reset own deck when planechase is disabled
     if (!includesPlanechase(mode)) setUseOwnDeck(false);
   };
@@ -136,7 +127,7 @@ export default function CreateGameScreen() {
       };
       await firestoreService.addPlayer(player, gameId);
 
-      trackEvent('create_game', { game_mode: gameMode, max_players: maxPlayers });
+      trackEvent('create_game', { game_mode: gameMode });
 
       router.replace({
         pathname: '/(app)/lobby/[gameId]',
@@ -189,31 +180,6 @@ export default function CreateGameScreen() {
         </View>
       )}
 
-      {/* Players stepper */}
-      <View style={styles.stepperRow}>
-        <Text style={styles.stepperLabel}>Players: {maxPlayers}</Text>
-        <View style={styles.stepperButtons}>
-          <TouchableOpacity
-            onPress={() => setMaxPlayers(Math.max(minPlayers, maxPlayers - 1))}
-            disabled={maxPlayers <= minPlayers}
-            accessibilityLabel="Decrease player count"
-            accessibilityRole="button"
-          >
-            <Text style={[styles.stepperBtn, maxPlayers <= minPlayers && styles.disabled]}>−</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => setMaxPlayers(Math.min(maxPlayerLimit, maxPlayers + 1))}
-            disabled={maxPlayers >= maxPlayerLimit}
-            accessibilityLabel="Increase player count"
-            accessibilityRole="button"
-          >
-            <Text style={[styles.stepperBtn, maxPlayers >= maxPlayerLimit && styles.disabled]}>
-              +
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </View>
-
       {/* Starting life stepper */}
       <View style={styles.stepperRow}>
         <Text style={styles.stepperLabel}>Starting Life: {startingLife}</Text>
@@ -236,29 +202,6 @@ export default function CreateGameScreen() {
           </TouchableOpacity>
         </View>
       </View>
-
-      {/* Role distribution (treachery modes only) */}
-      {hasTreachery && (
-        <>
-          {/* Ornate divider */}
-          <View style={styles.ornateDivider}>
-            <View style={styles.ornateLine} />
-            <Text style={styles.ornateDiamond}>&#9670;</Text>
-            <View style={styles.ornateLine} />
-          </View>
-
-          {/* Section header */}
-          <Text style={styles.roleHeader}>Role Distribution</Text>
-
-          {/* Role distribution */}
-          <View style={styles.roleBadges}>
-            <RoleBadge count={dist.leaders} role="leader" />
-            <RoleBadge count={dist.guardians} role="guardian" />
-            <RoleBadge count={dist.assassins} role="assassin" />
-            <RoleBadge count={dist.traitors} role="traitor" />
-          </View>
-        </>
-      )}
 
       {errorMessage && <ErrorBanner message={errorMessage} />}
 
@@ -370,32 +313,6 @@ const styles = StyleSheet.create({
   },
   disabled: {
     opacity: 0.3,
-  },
-  ornateDivider: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  ornateLine: {
-    flex: 1,
-    height: 1,
-    backgroundColor: colors.border,
-  },
-  ornateDiamond: {
-    color: colors.primary,
-    fontSize: 10,
-  },
-  roleHeader: {
-    color: colors.textSecondary,
-    fontSize: 12,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 1.5,
-    textAlign: 'center',
-  },
-  roleBadges: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
   },
   createButton: {
     backgroundColor: colors.primary,

--- a/Treachery/app/(app)/index.tsx
+++ b/Treachery/app/(app)/index.tsx
@@ -51,8 +51,18 @@ export default function HomeScreen() {
       }
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && authState === 'authenticated') {
+        checkForActiveGame();
+      }
+    };
+
     window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [authState, checkForActiveGame]);
 
   if (authState !== 'authenticated') return null;

--- a/Treachery/app/(app)/lobby/[gameId].tsx
+++ b/Treachery/app/(app)/lobby/[gameId].tsx
@@ -355,7 +355,7 @@ export default function LobbyScreen() {
 
       {/* Player list */}
       <Text style={styles.sectionTitle}>
-        Players ({players.length}/{game?.max_players ?? 0})
+        Players ({players.length})
       </Text>
 
       {players.length === 0 ? (

--- a/Treachery/src/hooks/useLobby.ts
+++ b/Treachery/src/hooks/useLobby.ts
@@ -60,8 +60,7 @@ export function useLobby(
     game?.game_mode === 'treachery' || game?.game_mode === 'treachery_planechase';
   const minPlayers = isTreacheryMode ? MINIMUM_PLAYER_COUNT : 1;
 
-  const canStartGame =
-    isHost && players.length >= minPlayers && players.length <= (game?.max_players ?? 0);
+  const canStartGame = isHost && players.length >= minPlayers;
 
   const startGame = useCallback(async () => {
     if (!isHost || !game) return;


### PR DESCRIPTION
## Summary
- **Remove player count stepper** from game creation on both iOS and web. Max players is now auto-set by game mode (8 for Treachery, 12 for Life Tracker). Roles are assigned by the Cloud Function at game start based on actual players — specifying count upfront was unnecessary friction.
- **Fix web rejoin flow** — added `visibilitychange` listener so the home screen re-checks for active games when the browser tab regains focus. Previously only `popstate` was handled, so closing/reopening a tab wouldn't show the rejoin banner.
- **Add shared Xcode scheme** for consistent builds across machines (TestFlight prep).

## Test plan
- [ ] Create a Treachery game on iOS — verify no player count stepper, game creates with max_players=8
- [ ] Create a Life Tracker game on web — verify no player count stepper, game creates with max_players=12
- [ ] Join a game, verify lobby shows "Players (X)" not "Players (X/Y)"
- [ ] Start a game with 4+ players, verify roles assigned correctly
- [ ] On web: join a game, close browser tab, reopen — verify rejoin banner appears on home screen
- [ ] Verify iOS Release build succeeds (xcodebuild)
- [ ] Verify web typecheck passes (npx tsc --noEmit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)