### PR TITLE
Add TestFlight download link to web app

### DIFF
--- a/Treachery/app/(app)/index.tsx
+++ b/Treachery/app/(app)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Linking } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '@/hooks/useAuth';
@@ -144,6 +144,15 @@ export default function HomeScreen() {
       </TouchableOpacity>
 
       <View style={styles.spacer} />
+
+      <TouchableOpacity
+        style={styles.testflightLink}
+        onPress={() => Linking.openURL('https://testflight.apple.com/join/Ws9HWGA7')}
+        accessibilityLabel="Download the iOS app on TestFlight"
+        accessibilityRole="link"
+      >
+        <Text style={styles.testflightLinkText}>Download the iOS App (TestFlight)</Text>
+      </TouchableOpacity>
 
       {/* Bottom navigation */}
       <View style={styles.bottomNav}>
@@ -298,5 +307,14 @@ const styles = StyleSheet.create({
   navLabel: {
     color: colors.textSecondary,
     fontSize: 12,
+  },
+  testflightLink: {
+    alignItems: 'center',
+  },
+  testflightLinkText: {
+    color: colors.textTertiary,
+    fontSize: 12,
+    fontFamily: fonts.serif,
+    fontStyle: 'italic',
   },
 });

--- a/Treachery/app/(auth)/login.tsx
+++ b/Treachery/app/(auth)/login.tsx
@@ -142,12 +142,21 @@ export default function LoginScreen() {
       <View style={styles.spacer} />
 
       <TouchableOpacity
-        style={styles.rulesLink}
+        style={styles.footerLink}
+        onPress={() => Linking.openURL('https://testflight.apple.com/join/Ws9HWGA7')}
+        accessibilityLabel="Download the iOS app on TestFlight"
+        accessibilityRole="link"
+      >
+        <Text style={styles.footerLinkText}>Download the iOS App (TestFlight)</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.footerLink}
         onPress={() => Linking.openURL('https://mtgtreachery.net')}
         accessibilityLabel="Learn the rules at MTGTreachery.net"
         accessibilityRole="link"
       >
-        <Text style={styles.rulesLinkText}>Learn the rules at MTGTreachery.net</Text>
+        <Text style={styles.footerLinkText}>Learn the rules at MTGTreachery.net</Text>
       </TouchableOpacity>
     </View>
   );
@@ -274,11 +283,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  rulesLink: {
+  footerLink: {
     alignItems: 'center',
-    paddingBottom: spacing.md,
+    paddingBottom: spacing.sm,
   },
-  rulesLinkText: {
+  footerLinkText: {
     color: colors.textTertiary,
     fontSize: 12,
     fontFamily: fonts.serif,


### PR DESCRIPTION
## Summary
- Adds a TestFlight download link (https://testflight.apple.com/join/Ws9HWGA7) to the login page and home page
- Login page: link appears above the existing "Learn the rules" link
- Home page: link appears above the bottom navigation bar

## Test plan
- [ ] Verify the TestFlight link appears on the login screen
- [ ] Verify the TestFlight link appears on the home screen
- [ ] Verify tapping the link opens the TestFlight URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)