### PR TITLE
Add manual dispatch to deploy workflows and split web/App Store

### DIFF
--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -10,44 +10,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy-web:
-    name: Deploy Web to Production
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: Treachery/package-lock.json
-
-      - name: Install web dependencies
-        run: npm ci
-        working-directory: Treachery
-
-      - name: Build web app
-        run: npm run build:web
-        working-directory: Treachery
-        env:
-          EXPO_PUBLIC_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          EXPO_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          EXPO_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          EXPO_PUBLIC_ENVIRONMENT: production
-
-      - name: Install functions dependencies
-        run: npm ci
-        working-directory: functions
-
-      - name: Deploy to Firebase
-        run: npx firebase-tools deploy --only hosting:production,functions,firestore:rules,firestore:indexes
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-
   deploy-ios:
     name: Submit iOS to App Store
     runs-on: macos-15

--- a/.github/workflows/deploy-internal-test.yml
+++ b/.github/workflows/deploy-internal-test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "TreacheryAndroid/**"
+  workflow_dispatch:
 
 concurrency:
   group: deploy-android-internal

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,6 +9,7 @@ on:
       - "firebase.json"
       - "firestore.rules"
       - "firestore.indexes.json"
+  workflow_dispatch:
 
 concurrency:
   group: deploy-staging

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "Treachery-iOS/**"
+  workflow_dispatch:
 
 concurrency:
   group: deploy-testflight

--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -1,0 +1,49 @@
+name: Deploy Web to Production
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Web & Functions to Production
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: Treachery/package-lock.json
+
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: Treachery
+
+      - name: Build web app
+        run: npm run build:web
+        working-directory: Treachery
+        env:
+          EXPO_PUBLIC_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          EXPO_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          EXPO_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          EXPO_PUBLIC_ENVIRONMENT: production
+
+      - name: Install functions dependencies
+        run: npm ci
+        working-directory: functions
+
+      - name: Deploy to Firebase
+        run: npx firebase-tools deploy --only hosting:production,functions,firestore:rules,firestore:indexes
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to staging, TestFlight, and Google Play internal test deploy workflows (production workflows already had it)
- Split `deploy-appstore.yml` into two independent workflows:
  - `deploy-web-production.yml` — web app + cloud functions + firestore rules
  - `deploy-appstore.yml` — iOS App Store submission only

## Test plan

- [x] Verify all deploy workflows show "Run workflow" button in Actions UI
- [x] Verify `deploy-appstore.yml` no longer contains the web deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)