### PR TITLE
Fix planechase die roll broadcasting and desktop plane display

### DIFF
--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   Modal,
   ScrollView,
+  Image,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -256,6 +257,23 @@ export default function GameBoardScreen() {
             )}
 
             {isPlanechaseActive && isChaoticAetherActive && <ChaoticAetherBanner />}
+
+            {/* Always-visible plane card image (rotated 90° clockwise) */}
+            {isPlanechaseActive && !isOwnDeckMode && currentPlane?.image_uri && (
+              <TouchableOpacity
+                style={styles.sidebarImageContainer}
+                onPress={() => setShowPlaneDetail(true)}
+                activeOpacity={0.8}
+                accessibilityLabel={`View ${currentPlane.name} details`}
+                accessibilityRole="button"
+              >
+                <Image
+                  source={{ uri: currentPlane.image_uri }}
+                  style={styles.sidebarPlaneImage}
+                  resizeMode="contain"
+                />
+              </TouchableOpacity>
+            )}
 
             <View style={{ flex: 1 }} />
 
@@ -573,6 +591,21 @@ const styles = StyleSheet.create({
   },
   mainContent: {
     flex: 1,
+  },
+  sidebarImageContainer: {
+    margin: 12,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sidebarPlaneImage: {
+    width: '73%',
+    aspectRatio: 457 / 626,
+    transform: [{ rotate: '90deg' }],
   },
   centerContainer: {
     flex: 1,

--- a/Treachery/src/hooks/useGameBoard.ts
+++ b/Treachery/src/hooks/useGameBoard.ts
@@ -50,7 +50,6 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
   const hasReceivedFirstSnapshot = useRef(false);
 
   // Planechase transient state
-  const [dieRollResult, setDieRollResult] = useState<string | null>(null);
   const [isRollingDie, setIsRollingDie] = useState(false);
   const [tunnelOptions, setTunnelOptions] = useState<PlaneCard[] | null>(null);
 
@@ -166,6 +165,10 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
     return game?.planechase?.die_roll_count ?? 0;
   }, [game?.planechase?.die_roll_count]);
 
+  const dieRollResult = useMemo(() => {
+    return game?.planechase?.last_die_result ?? null;
+  }, [game?.planechase?.last_die_result]);
+
   // ── All game actions now go through Cloud Functions ───────────────────
   // Win condition checking happens server-side automatically.
 
@@ -280,7 +283,6 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
     if (isRollingDie || isPending) return;
     setErrorMessage(null);
     setIsRollingDie(true);
-    setDieRollResult(null);
 
     try {
       const rollDieFn = httpsCallable<{ gameId: string }, { result: string }>(
@@ -288,7 +290,6 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
         'rollPlanarDie',
       );
       const response = await rollDieFn({ gameId });
-      setDieRollResult(response.data.result);
       trackEvent('roll_planar_die', { result: response.data.result });
     } catch (error: unknown) {
       setErrorMessage(error instanceof Error ? error.message : 'Failed to roll die.');

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -17,6 +17,7 @@ export interface PlanechaseState {
   used_plane_ids: string[];
   last_die_roller_id: string | null;
   die_roll_count: number;
+  last_die_result?: string | null;
   chaotic_aether_active?: boolean;
   secondary_plane_id?: string;
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -775,7 +775,7 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
   const { gameId } = request.data;
   if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
 
-  return db.runTransaction(async (tx) => {
+  const result = await db.runTransaction(async (tx) => {
     const gameRef = db.doc(`games/${gameId}`);
     const gameSnap = await tx.get(gameRef);
     if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
@@ -799,16 +799,16 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
 
     // Roll: 0-3 blank, 4 chaos, 5 planeswalk
     const roll = Math.floor(Math.random() * 6);
-    let result;
+    let dieResult;
     let newPlaneId = planechase.current_plane_id || null;
     let usedPlaneIds = planechase.used_plane_ids || [];
 
     if (roll < 4) {
-      result = "blank";
+      dieResult = "blank";
     } else if (roll === 4) {
-      result = "chaos";
+      dieResult = "chaos";
     } else {
-      result = "planeswalk";
+      dieResult = "planeswalk";
 
       if (!planechase.use_own_deck) {
         // Pick next plane (including phenomena this time - they get encountered)
@@ -825,20 +825,21 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
     }
 
     // Chaotic Aether: while active, blank rolls become chaos
-    if (planechase.chaotic_aether_active && result === "blank") {
-      result = "chaos";
+    if (planechase.chaotic_aether_active && dieResult === "blank") {
+      dieResult = "chaos";
     }
 
     const updateData = {
       "planechase.last_die_roller_id": uid,
       "planechase.die_roll_count": rollCount,
+      "planechase.last_die_result": dieResult,
       "planechase.current_plane_id": newPlaneId,
       "planechase.used_plane_ids": usedPlaneIds,
       last_activity_at: FieldValue.serverTimestamp(),
     };
 
     // Planeswalking resets Chaotic Aether and clears Spatial Merging
-    if (result === "planeswalk") {
+    if (dieResult === "planeswalk") {
       updateData["planechase.chaotic_aether_active"] = false;
       updateData["planechase.secondary_plane_id"] = null;
     }
@@ -846,11 +847,11 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
     tx.update(gameRef, updateData);
 
     // Build response
-    const response = { result, manaCost, newPlaneId };
+    const response = { result: dieResult, manaCost, newPlaneId };
 
     // When chaos ensues, include the chaos ability info so the client
     // can display the effect without needing its own plane card database
-    if (result === "chaos") {
+    if (dieResult === "chaos") {
       const currentPlane = getPlaneCard(planechase.current_plane_id);
       if (currentPlane) {
         const chaosText = parseChaosAbility(currentPlane.oracle_text);
@@ -880,6 +881,43 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
 
     return response;
   });
+
+  // Send push notifications for chaos and planeswalk results
+  if (result.result === "chaos" || result.result === "planeswalk") {
+    try {
+      const playerSnap = await db
+        .collection(`games/${gameId}/players`)
+        .where("user_id", "==", uid)
+        .limit(1)
+        .get();
+      const rollerName =
+        playerSnap.docs[0]?.data()?.display_name ?? "A player";
+
+      if (result.result === "chaos") {
+        const planeName = result.chaosAbility?.planeName ?? "the current plane";
+        await notifyPlayers(
+          gameId,
+          uid,
+          "Chaos Ensues!",
+          `${rollerName} rolled chaos on ${planeName}.`
+        );
+      } else {
+        const newPlane = getPlaneCard(result.newPlaneId);
+        const planeName = newPlane?.name ?? "a new plane";
+        await notifyPlayers(
+          gameId,
+          uid,
+          "Planeswalk!",
+          `${rollerName} planeswalked to ${planeName}.`
+        );
+      }
+    } catch (e) {
+      // Non-critical: don't fail the roll if notification fails
+      console.error("Failed to send planechase notification:", e);
+    }
+  }
+
+  return result;
 });
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Die roll broadcasting**: Persist `last_die_result` in Firestore so all players see chaos/planeswalk results in real-time (previously only visible to the roller via local state)
- **Push notifications**: Send FCM notifications for chaos ("Chaos Ensues!") and planeswalk ("Planeswalk!") rolls to all other players
- **Desktop plane image**: Always show the current plane card image rotated 90° clockwise in the desktop sidebar without requiring a tap

## Test plan
- [ ] Roll planar die and verify all connected clients see the result (chaos/planeswalk/blank)
- [ ] Verify push notifications arrive for chaos and planeswalk rolls (not blanks)
- [ ] Verify desktop sidebar shows the plane card image rotated 90° clockwise
- [ ] Verify tapping the sidebar image opens the plane detail modal
- [ ] Verify Chaotic Aether blank→chaos override still triggers notifications
- [ ] Verify notification failure doesn't break the die roll

🤖 Generated with [Claude Code](https://claude.com/claude-code)