### PR TITLE
Override signing to Manual with Apple Distribution on CI

### DIFF
--- a/Treachery-iOS/fastlane/Fastfile
+++ b/Treachery-iOS/fastlane/Fastfile
@@ -52,13 +52,14 @@ platform :ios do
       xcodeproj: XCODEPROJ
     )
 
-    # Build
+    # Build (override signing for CI — project uses Automatic but CI needs Manual)
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true
+      clean: true,
+      xcargs: "CODE_SIGN_STYLE='Manual' CODE_SIGN_IDENTITY='Apple Distribution'"
     )
 
     # Upload to TestFlight
@@ -99,13 +100,14 @@ platform :ios do
       xcodeproj: XCODEPROJ
     )
 
-    # Build
+    # Build (override signing for CI — project uses Automatic but CI needs Manual)
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true
+      clean: true,
+      xcargs: "CODE_SIGN_STYLE='Manual' CODE_SIGN_IDENTITY='Apple Distribution'"
     )
 
     # Upload and submit for review


### PR DESCRIPTION
## Summary
- Follow-up to #43 — cert/profile now import correctly into Fastlane's keychain, but `setup_ci` disables automatic signing and the project is configured for `Automatic` + `Apple Development`
- Adds `xcargs` to `build_app` in both beta and release lanes to override to `Manual` signing with `Apple Distribution` identity, matching the distribution cert and App Store profile from secrets

## Test plan
- [ ] Merge and re-run "Deploy to TestFlight" workflow
- [ ] Verify build signs and uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)