### PR TITLE
Use targeted manual signing for app target only

### DIFF
--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -52,4 +52,5 @@ jobs:
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           PROFILE_PATH: ${{ runner.temp }}/build_pp.mobileprovision
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: bundle exec fastlane release

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -54,4 +54,5 @@ jobs:
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           PROFILE_PATH: ${{ runner.temp }}/build_pp.mobileprovision
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: bundle exec fastlane beta

--- a/Treachery-iOS/fastlane/Fastfile
+++ b/Treachery-iOS/fastlane/Fastfile
@@ -34,7 +34,17 @@ platform :ios do
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
       )
-      install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_uuid = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+
+      # Switch only the app target to manual signing (SPM packages stay automatic)
+      update_code_signing_settings(
+        use_automatic_signing: false,
+        path: XCODEPROJ,
+        team_id: ENV["TEAM_ID"],
+        code_sign_identity: "Apple Distribution",
+        profile_uuid: profile_uuid,
+        targets: ["Treachery-iOS"]
+      )
     end
 
     # Fetch App Store Connect API key from environment
@@ -52,14 +62,13 @@ platform :ios do
       xcodeproj: XCODEPROJ
     )
 
-    # Build (override signing for CI — project uses Automatic but CI needs Manual)
+    # Build
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true,
-      xcargs: "CODE_SIGN_STYLE='Manual' CODE_SIGN_IDENTITY='Apple Distribution'"
+      clean: true
     )
 
     # Upload to TestFlight
@@ -83,7 +92,17 @@ platform :ios do
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
       )
-      install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_uuid = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+
+      # Switch only the app target to manual signing (SPM packages stay automatic)
+      update_code_signing_settings(
+        use_automatic_signing: false,
+        path: XCODEPROJ,
+        team_id: ENV["TEAM_ID"],
+        code_sign_identity: "Apple Distribution",
+        profile_uuid: profile_uuid,
+        targets: ["Treachery-iOS"]
+      )
     end
 
     api_key = app_store_connect_api_key(
@@ -100,14 +119,13 @@ platform :ios do
       xcodeproj: XCODEPROJ
     )
 
-    # Build (override signing for CI — project uses Automatic but CI needs Manual)
+    # Build
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true,
-      xcargs: "CODE_SIGN_STYLE='Manual' CODE_SIGN_IDENTITY='Apple Distribution'"
+      clean: true
     )
 
     # Upload and submit for review


### PR DESCRIPTION
## Summary
- The global `xcargs: "CODE_SIGN_STYLE='Manual'"` was applying to ALL targets including SPM packages (Firebase, gRPC, nanopb, etc.), which then all failed with "requires a development team"
- Now uses `update_code_signing_settings` to switch **only the Treachery-iOS target** to manual signing with the installed profile UUID — SPM packages keep automatic signing
- Requires a new `TEAM_ID` secret (your Apple Developer Team ID) in both staging and production environments

## Setup required
Add a `TEAM_ID` secret to both the **staging** and **production** GitHub environments with your Apple Developer Team ID.

Also: the build logs showed `"Treachery-iOS" requires a provisioning profile with the Push Notifications feature`. Make sure your `PROVISIONING_PROFILE_BASE64` secret contains an App Store profile that includes the **Push Notifications** capability (regenerate in Apple Developer portal > Profiles if needed).

## Test plan
- [ ] Add `TEAM_ID` secret to staging environment
- [ ] Ensure provisioning profile has Push Notifications capability
- [ ] Merge and re-run "Deploy to TestFlight" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)