### PR TITLE
Fix profile UUID extraction for CI signing

### DIFF
--- a/Treachery-iOS/fastlane/Fastfile
+++ b/Treachery-iOS/fastlane/Fastfile
@@ -34,7 +34,8 @@ platform :ios do
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
       )
-      profile_uuid = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_path = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_uuid = File.basename(profile_path, ".mobileprovision")
 
       # Switch only the app target to manual signing (SPM packages stay automatic)
       update_code_signing_settings(
@@ -92,7 +93,8 @@ platform :ios do
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
       )
-      profile_uuid = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_path = install_provisioning_profile(path: ENV["PROFILE_PATH"])
+      profile_uuid = File.basename(profile_path, ".mobileprovision")
 
       # Switch only the app target to manual signing (SPM packages stay automatic)
       update_code_signing_settings(


### PR DESCRIPTION
## Summary
- `install_provisioning_profile` returns the installed **file path**, not the UUID
- The full path was being passed as `profile_uuid` to `update_code_signing_settings`, causing Xcode to try matching on the literal path string
- Now extracts the UUID from the filename (e.g. `983c33f3-...be.mobileprovision` → `983c33f3-...be`)

## Test plan
- [ ] Merge and re-run "Deploy to TestFlight" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)