### PR TITLE
Rewrite CI signing: use -allowProvisioningUpdates instead of manual signing

### DIFF
--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -36,13 +36,10 @@ jobs:
       - name: Resolve Swift packages
         run: xcodebuild -resolvePackageDependencies -project Treachery-iOS.xcodeproj -scheme Treachery-iOS
 
-      - name: Decode signing assets
+      - name: Decode signing certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_certificate.p12
-          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_pp.mobileprovision
+        run: echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_certificate.p12
 
       - name: Build and submit to App Store
         env:
@@ -51,6 +48,4 @@ jobs:
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          PROFILE_PATH: ${{ runner.temp }}/build_pp.mobileprovision
-          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: bundle exec fastlane release

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -38,13 +38,10 @@ jobs:
       - name: Resolve Swift packages
         run: xcodebuild -resolvePackageDependencies -project Treachery-iOS.xcodeproj -scheme Treachery-iOS
 
-      - name: Decode signing assets
+      - name: Decode signing certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_certificate.p12
-          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_pp.mobileprovision
+        run: echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/build_certificate.p12
 
       - name: Build and upload to TestFlight
         env:
@@ -53,6 +50,4 @@ jobs:
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          PROFILE_PATH: ${{ runner.temp }}/build_pp.mobileprovision
-          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: bundle exec fastlane beta

--- a/Treachery-iOS/fastlane/Fastfile
+++ b/Treachery-iOS/fastlane/Fastfile
@@ -20,31 +20,38 @@ platform :ios do
     )
   end
 
+  # ── Shared CI setup ──────────────────────────────────────
+
+  # Writes the App Store Connect API key to a .p8 file and returns
+  # the xcargs string needed for -allowProvisioningUpdates.
+  # This lets xcodebuild resolve signing automatically on CI
+  # (profiles, Push Notifications, etc.) without manual overrides.
+  private_lane :ci_signing_xcargs do
+    require "base64"
+    api_key_path = File.join(Dir.tmpdir, "AuthKey_#{ENV['APP_STORE_CONNECT_KEY_ID']}.p8")
+    File.write(api_key_path, Base64.decode64(ENV["APP_STORE_CONNECT_KEY"]))
+
+    [
+      "-allowProvisioningUpdates",
+      "-authenticationKeyPath '#{api_key_path}'",
+      "-authenticationKeyID '#{ENV['APP_STORE_CONNECT_KEY_ID']}'",
+      "-authenticationKeyIssuerID '#{ENV['APP_STORE_CONNECT_ISSUER_ID']}'"
+    ].join(" ")
+  end
+
   # ── Beta (TestFlight) ─────────────────────────────────
 
   desc "Build and upload to TestFlight"
   lane :beta do
     setup_ci if is_ci
 
-    # Import signing assets into Fastlane's temp keychain
+    # Import distribution certificate into Fastlane's temp keychain
     if is_ci
       import_certificate(
         certificate_path: ENV["CERTIFICATE_PATH"],
         certificate_password: ENV["P12_PASSWORD"],
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
-      )
-      profile_path = install_provisioning_profile(path: ENV["PROFILE_PATH"])
-      profile_uuid = File.basename(profile_path, ".mobileprovision")
-
-      # Switch only the app target to manual signing (SPM packages stay automatic)
-      update_code_signing_settings(
-        use_automatic_signing: false,
-        path: XCODEPROJ,
-        team_id: ENV["TEAM_ID"],
-        code_sign_identity: "Apple Distribution",
-        profile_uuid: profile_uuid,
-        targets: ["Treachery-iOS"]
       )
     end
 
@@ -63,13 +70,18 @@ platform :ios do
       xcodeproj: XCODEPROJ
     )
 
-    # Build
+    # Build — use -allowProvisioningUpdates on CI so xcodebuild
+    # resolves profiles automatically (handles Push Notifications,
+    # SPM packages, etc. without manual signing overrides)
+    signing_args = is_ci ? ci_signing_xcargs : ""
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true
+      clean: true,
+      xcargs: signing_args,
+      export_xcargs: signing_args
     )
 
     # Upload to TestFlight
@@ -85,25 +97,13 @@ platform :ios do
   lane :release do
     setup_ci if is_ci
 
-    # Import signing assets into Fastlane's temp keychain
+    # Import distribution certificate into Fastlane's temp keychain
     if is_ci
       import_certificate(
         certificate_path: ENV["CERTIFICATE_PATH"],
         certificate_password: ENV["P12_PASSWORD"],
         keychain_name: "fastlane_tmp_keychain",
         keychain_password: ""
-      )
-      profile_path = install_provisioning_profile(path: ENV["PROFILE_PATH"])
-      profile_uuid = File.basename(profile_path, ".mobileprovision")
-
-      # Switch only the app target to manual signing (SPM packages stay automatic)
-      update_code_signing_settings(
-        use_automatic_signing: false,
-        path: XCODEPROJ,
-        team_id: ENV["TEAM_ID"],
-        code_sign_identity: "Apple Distribution",
-        profile_uuid: profile_uuid,
-        targets: ["Treachery-iOS"]
       )
     end
 
@@ -122,12 +122,15 @@ platform :ios do
     )
 
     # Build
+    signing_args = is_ci ? ci_signing_xcargs : ""
     build_app(
       project: XCODEPROJ,
       scheme: SCHEME,
       export_method: "app-store",
       output_directory: "./build",
-      clean: true
+      clean: true,
+      xcargs: signing_args,
+      export_xcargs: signing_args
     )
 
     # Upload and submit for review


### PR DESCRIPTION
## Summary

Completely different approach to CI code signing. Instead of manually switching to manual signing (which caused a cascade of issues with SPM packages, profile UUID extraction, export options, and Push Notifications), this uses **`-allowProvisioningUpdates` with App Store Connect API key authentication**.

This lets `xcodebuild` resolve provisioning profiles automatically on CI — the same way Xcode does locally. It handles:
- Push Notifications capability
- SPM package signing (no global overrides)
- Export step profile mapping (automatic)
- Profile creation/download (automatic)

### What changed
- **Fastfile**: Removed `install_provisioning_profile`, `update_code_signing_settings`, and `export_options`. Added a shared `ci_signing_xcargs` helper that writes the API key to a `.p8` file and returns the `-allowProvisioningUpdates` flags. Passed to both `xcargs` (archive) and `export_xcargs` (export).
- **Workflows**: Simplified to only decode the certificate. No more provisioning profile decoding.

### Secrets no longer needed
- `PROVISIONING_PROFILE_BASE64` — xcodebuild downloads/creates profiles automatically
- `TEAM_ID` — resolved from the Xcode project
- `KEYCHAIN_PASSWORD` — was already removed

### Secrets still required
- `BUILD_CERTIFICATE_BASE64` — the Apple Distribution certificate
- `P12_PASSWORD` — certificate password
- `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_KEY` — API key for authentication

## Test plan
- [ ] Merge and re-run "Deploy to TestFlight" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)