### PR TITLE
Remove duplicate export_xcargs causing auth flag collision

### DIFF
--- a/Treachery-iOS/fastlane/Fastfile
+++ b/Treachery-iOS/fastlane/Fastfile
@@ -80,8 +80,7 @@ platform :ios do
       export_method: "app-store",
       output_directory: "./build",
       clean: true,
-      xcargs: signing_args,
-      export_xcargs: signing_args
+      xcargs: signing_args
     )
 
     # Upload to TestFlight
@@ -129,8 +128,7 @@ platform :ios do
       export_method: "app-store",
       output_directory: "./build",
       clean: true,
-      xcargs: signing_args,
-      export_xcargs: signing_args
+      xcargs: signing_args
     )
 
     # Upload and submit for review


### PR DESCRIPTION
## Summary
The archive step succeeds, but the export step fails with `option '-authenticationKeyPath' may only be provided once`. Fastlane automatically injects the API key auth flags into the export step from the `app_store_connect_api_key` context — our explicit `export_xcargs` duplicated them. Removed `export_xcargs` from both lanes.

## Test plan
- [ ] Merge and re-run "Deploy to TestFlight" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)