### PR TITLE
Fix xcodebuild settings timeout on CI

### DIFF
--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -48,4 +48,5 @@ jobs:
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30
         run: bundle exec fastlane release

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -50,4 +50,5 @@ jobs:
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30
         run: bundle exec fastlane beta

--- a/Treachery-iOS/Treachery-iOS.xcodeproj/project.pbxproj
+++ b/Treachery-iOS/Treachery-iOS.xcodeproj/project.pbxproj
@@ -463,7 +463,8 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				"INFOPLIST_KEY_UISupportedInterfaceOrientations~ipad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -511,7 +512,8 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				"INFOPLIST_KEY_UISupportedInterfaceOrientations~ipad" = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";

--- a/Treachery-iOS/Treachery-iOS/Treachery_iOSApp.swift
+++ b/Treachery-iOS/Treachery-iOS/Treachery_iOSApp.swift
@@ -49,6 +49,15 @@ class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, UNUserNot
         return true
     }
 
+    // MARK: - Orientation Lock (portrait only on iPhone)
+
+    func application(
+        _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
+        return .portrait
+    }
+
     // MARK: - Phone Auth APNs Support
 
     func application(


### PR DESCRIPTION
## Summary
- The latest deploy failed because `xcodebuild -showBuildSettings` timed out with the default 3-second timeout (retried 4 times up to 24s total)
- Sets `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=30` in both deploy workflows to handle CI runners with SPM dependencies that take longer to resolve
- **Note**: The previous run (PR #50 merge) actually succeeded through archive + export + upload, only failing on App Store validation (iPad orientation) — that's already fixed in main. This timeout was an intermittent issue on the manual re-run.

## Test plan
- [ ] Merge and re-run "Deploy to TestFlight" workflow
- [ ] `xcodebuild -showBuildSettings` should complete within 30s
- [ ] Full pipeline: archive → export → upload should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)