### PR TITLE
Fix dev tools not showing on staging builds

### DIFF
--- a/Treachery/app/(app)/dev-test-abilities.tsx
+++ b/Treachery/app/(app)/dev-test-abilities.tsx
@@ -405,7 +405,8 @@ export default function DevTestAbilitiesScreen() {
     setShowSheet(false);
   };
 
-  if (!__DEV__) return null;
+  const isDevToolsEnabled = process.env.EXPO_PUBLIC_ENVIRONMENT !== 'production';
+  if (!isDevToolsEnabled) return null;
 
   return (
     <View style={styles.container}>

--- a/Treachery/app/(app)/index.tsx
+++ b/Treachery/app/(app)/index.tsx
@@ -146,7 +146,7 @@ export default function HomeScreen() {
         <Text style={styles.secondaryButtonText}>Join Game</Text>
       </TouchableOpacity>
 
-      {__DEV__ && (
+      {process.env.EXPO_PUBLIC_ENVIRONMENT !== 'production' && (
         <TouchableOpacity
           style={styles.secondaryButton}
           onPress={() => router.push('/(app)/dev-test-abilities')}


### PR DESCRIPTION
## Summary
- Replaces `__DEV__` gate with `EXPO_PUBLIC_ENVIRONMENT !== 'production'` for the dev ability testing tool
- `__DEV__` is only `true` in the local Expo dev server — deployed staging builds had it set to `false`, hiding the tool
- Now visible on both local dev and staging, hidden on production

## Test plan
- [ ] Dev tool button visible on staging build (treachery-staging.web.app)
- [ ] Dev tool button visible when running locally (`npx expo start`)
- [ ] Dev tool button hidden on production build (`EXPO_PUBLIC_ENVIRONMENT=production`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)