### PR TITLE
Fix joinGame, add lobby ready-up + settings, fix onboarding bugs

### DIFF
--- a/Treachery-iOS/Treachery-iOS/Auth/DisplayNamePromptView.swift
+++ b/Treachery-iOS/Treachery-iOS/Auth/DisplayNamePromptView.swift
@@ -42,6 +42,11 @@ struct DisplayNamePromptView: View {
                 .textContentType(.name)
                 .autocapitalization(.words)
                 .disabled(isSaving)
+                .onChange(of: displayName) { _, newValue in
+                    if newValue.count > 30 {
+                        displayName = String(newValue.prefix(30))
+                    }
+                }
 
             if let error = validationError {
                 MtgErrorBanner(message: error)

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyBottomButtons.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyBottomButtons.swift
@@ -30,10 +30,16 @@ struct LobbyBottomButtons: View {
                 .buttonStyle(MtgPrimaryButtonStyle(isDisabled: !viewModel.canStartGame || viewModel.isStartingGame))
                 .disabled(!viewModel.canStartGame || viewModel.isStartingGame)
 
-                if !viewModel.canStartGame && viewModel.players.count < viewModel.minimumPlayerCount {
-                    Text("Need at least \(viewModel.minimumPlayerCount) player\(viewModel.minimumPlayerCount == 1 ? "" : "s") to start")
-                        .font(.caption)
-                        .foregroundStyle(Color.mtgTextSecondary)
+                if !viewModel.canStartGame {
+                    if viewModel.players.count < viewModel.minimumPlayerCount {
+                        Text("Need at least \(viewModel.minimumPlayerCount) player\(viewModel.minimumPlayerCount == 1 ? "" : "s") to start")
+                            .font(.caption)
+                            .foregroundStyle(Color.mtgTextSecondary)
+                    } else if !viewModel.allPlayersReady {
+                        Text("All players must be ready to start")
+                            .font(.caption)
+                            .foregroundStyle(Color.mtgTextSecondary)
+                    }
                 }
             }
 

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyPlayerRow.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyPlayerRow.swift
@@ -45,6 +45,13 @@ struct LobbyPlayerRow: View {
 
                 Spacer()
 
+                if player.isReady {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.green)
+                        .font(.body)
+                        .transition(.scale.combined(with: .opacity))
+                }
+
                 if isHost {
                     MtgBadge(text: "Host", foregroundColor: .mtgGold, backgroundColor: Color.mtgGold.opacity(0.15), font: .caption)
                 }

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
@@ -139,6 +139,11 @@ struct LobbyView: View {
                 .padding(.horizontal)
                 .padding(.vertical, 12)
 
+            if viewModel.isHost {
+                gameSettingsSection
+                    .padding(.bottom, 8)
+            }
+
             playerListSection
 
             if let error = viewModel.errorMessage {
@@ -162,6 +167,137 @@ struct LobbyView: View {
                 }
             )
         }
+    }
+
+    // MARK: - Game Settings (Host Only)
+
+    private var gameSettingsSection: some View {
+        VStack(spacing: 12) {
+            MtgSectionHeader(title: "Game Settings")
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let game = viewModel.game {
+                VStack(spacing: 12) {
+                    // Max Players
+                    HStack {
+                        Text("Max Players")
+                            .foregroundStyle(Color.mtgTextSecondary)
+                            .font(.subheadline)
+                        Spacer()
+                        HStack(spacing: 12) {
+                            Button {
+                                let newVal = max(2, game.maxPlayers - 1)
+                                Task { await viewModel.updateGameSettings(maxPlayers: newVal) }
+                            } label: {
+                                Image(systemName: "minus.circle")
+                                    .foregroundStyle(game.maxPlayers > 2 ? Color.mtgGold : Color.mtgTextSecondary.opacity(0.3))
+                            }
+                            .disabled(game.maxPlayers <= 2)
+
+                            Text("\(game.maxPlayers)")
+                                .foregroundStyle(Color.mtgTextPrimary)
+                                .fontWeight(.semibold)
+                                .frame(width: 24, alignment: .center)
+
+                            Button {
+                                let newVal = min(8, game.maxPlayers + 1)
+                                Task { await viewModel.updateGameSettings(maxPlayers: newVal) }
+                            } label: {
+                                Image(systemName: "plus.circle")
+                                    .foregroundStyle(game.maxPlayers < 8 ? Color.mtgGold : Color.mtgTextSecondary.opacity(0.3))
+                            }
+                            .disabled(game.maxPlayers >= 8)
+                        }
+                    }
+
+                    Rectangle().fill(Color.mtgDivider).frame(height: 1)
+
+                    // Starting Life
+                    HStack {
+                        Text("Starting Life")
+                            .foregroundStyle(Color.mtgTextSecondary)
+                            .font(.subheadline)
+                        Spacer()
+                        Menu {
+                            ForEach([20, 25, 30, 40, 50], id: \.self) { life in
+                                Button("\(life)") {
+                                    Task { await viewModel.updateGameSettings(startingLife: life) }
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text("\(game.startingLife)")
+                                    .foregroundStyle(Color.mtgTextPrimary)
+                                    .fontWeight(.semibold)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .foregroundStyle(Color.mtgGold)
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+
+                    Rectangle().fill(Color.mtgDivider).frame(height: 1)
+
+                    // Game Mode
+                    HStack {
+                        Text("Game Mode")
+                            .foregroundStyle(Color.mtgTextSecondary)
+                            .font(.subheadline)
+                        Spacer()
+                        Menu {
+                            ForEach(GameMode.allCases, id: \.self) { mode in
+                                Button(mode.displayName) {
+                                    Task { await viewModel.updateGameSettings(gameMode: mode.rawValue) }
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text(game.gameMode.displayName)
+                                    .foregroundStyle(Color.mtgTextPrimary)
+                                    .fontWeight(.semibold)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .foregroundStyle(Color.mtgGold)
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .padding(16)
+                .mtgCardFrame()
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - Ready Toggle
+
+    private var readyToggle: some View {
+        Button {
+            Task { await viewModel.toggleReady() }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: viewModel.currentPlayer?.isReady == true ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(viewModel.currentPlayer?.isReady == true ? Color.green : Color.mtgTextSecondary)
+                Text(viewModel.currentPlayer?.isReady == true ? "Ready" : "Not Ready")
+                    .fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                viewModel.currentPlayer?.isReady == true
+                    ? Color.green.opacity(0.15)
+                    : Color.mtgSurface
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                        viewModel.currentPlayer?.isReady == true ? Color.green.opacity(0.5) : Color.mtgDivider,
+                        lineWidth: 1
+                    )
+            )
+        }
+        .foregroundStyle(viewModel.currentPlayer?.isReady == true ? Color.green : Color.mtgTextPrimary)
     }
 
     // MARK: - Player List
@@ -220,6 +356,12 @@ struct LobbyView: View {
                     .animation(.easeInOut(duration: 0.3), value: viewModel.players.map(\.id))
                     .mtgCardFrame()
                     .padding(.horizontal)
+                }
+
+                if viewModel.players.count >= 2 {
+                    readyToggle
+                        .padding(.top, 16)
+                        .padding(.horizontal)
                 }
 
                 if !viewModel.isHost {

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
@@ -33,7 +33,12 @@ final class LobbyViewModel: ObservableObject {
     var canStartGame: Bool {
         guard let game = game else { return false }
         let minPlayers = game.gameMode.includesTreachery ? Role.minimumPlayerCount : 1
-        return isHost && players.count >= minPlayers
+        let allReady = players.count < 2 || players.allSatisfy { $0.isReady }
+        return isHost && players.count >= minPlayers && allReady
+    }
+
+    var allPlayersReady: Bool {
+        players.count < 2 || players.allSatisfy { $0.isReady }
     }
 
     var minimumPlayerCount: Int {
@@ -137,6 +142,24 @@ final class LobbyViewModel: ObservableObject {
         guard let player = currentPlayer else { return }
         do {
             try await firestoreManager.updateCommanderName(gameId: gameId, playerId: player.id, name: name)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func updateGameSettings(maxPlayers: Int? = nil, startingLife: Int? = nil, gameMode: String? = nil) async {
+        guard isHost else { return }
+        do {
+            try await cloudFunctions.updateGameSettings(gameId: gameId, maxPlayers: maxPlayers, startingLife: startingLife, gameMode: gameMode)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleReady() async {
+        guard let player = currentPlayer else { return }
+        do {
+            try await firestoreManager.updatePlayerReady(gameId: gameId, playerId: player.id, isReady: !player.isReady)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Treachery-iOS/Treachery-iOS/Managers/CloudFunctions.swift
+++ b/Treachery-iOS/Treachery-iOS/Managers/CloudFunctions.swift
@@ -141,4 +141,13 @@ struct CloudFunctions: CloudFunctionsProtocol {
         }
         _ = try await callable.call(data)
     }
+
+    func updateGameSettings(gameId: String, maxPlayers: Int?, startingLife: Int?, gameMode: String?) async throws {
+        let callable = functions.httpsCallable("updateGameSettings")
+        var data: [String: Any] = ["gameId": gameId]
+        if let maxPlayers { data["maxPlayers"] = maxPlayers }
+        if let startingLife { data["startingLife"] = startingLife }
+        if let gameMode { data["gameMode"] = gameMode }
+        _ = try await callable.call(data)
+    }
 }

--- a/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
+++ b/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
@@ -299,4 +299,8 @@ final class FirestoreManager: FirestoreManaging {
             try await playersCollection(gameId: gameId).document(playerId).updateData(["commander_name": FieldValue.delete()])
         }
     }
+
+    func updatePlayerReady(gameId: String, playerId: String, isReady: Bool) async throws {
+        try await playersCollection(gameId: gameId).document(playerId).updateData(["is_ready": isReady])
+    }
 }

--- a/Treachery-iOS/Treachery-iOS/Models/Player.swift
+++ b/Treachery-iOS/Treachery-iOS/Models/Player.swift
@@ -22,6 +22,7 @@ struct Player: Codable, Identifiable, Equatable {
     var commanderName: String?
     var originalIdentityCardId: String?
     var isFaceDown: Bool
+    var isReady: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -38,6 +39,7 @@ struct Player: Codable, Identifiable, Equatable {
         case commanderName = "commander_name"
         case originalIdentityCardId = "original_identity_card_id"
         case isFaceDown = "is_face_down"
+        case isReady = "is_ready"
     }
 
     // Custom decoder: uses decodeIfPresent for 'id' to handle documents
@@ -60,6 +62,7 @@ struct Player: Codable, Identifiable, Equatable {
         commanderName = try container.decodeIfPresent(String.self, forKey: .commanderName)
         originalIdentityCardId = try container.decodeIfPresent(String.self, forKey: .originalIdentityCardId)
         isFaceDown = try container.decodeIfPresent(Bool.self, forKey: .isFaceDown) ?? false
+        isReady = try container.decodeIfPresent(Bool.self, forKey: .isReady) ?? false
     }
 
     init(
@@ -76,7 +79,8 @@ struct Player: Codable, Identifiable, Equatable {
         playerColor: String? = nil,
         commanderName: String? = nil,
         originalIdentityCardId: String? = nil,
-        isFaceDown: Bool = false
+        isFaceDown: Bool = false,
+        isReady: Bool = false
     ) {
         self.id = id
         self.orderId = orderId
@@ -92,5 +96,6 @@ struct Player: Codable, Identifiable, Equatable {
         self.commanderName = commanderName
         self.originalIdentityCardId = originalIdentityCardId
         self.isFaceDown = isFaceDown
+        self.isReady = isReady
     }
 }

--- a/Treachery-iOS/Treachery-iOS/Protocols/CloudFunctionsProtocol.swift
+++ b/Treachery-iOS/Treachery-iOS/Protocols/CloudFunctionsProtocol.swift
@@ -15,4 +15,5 @@ protocol CloudFunctionsProtocol {
     func resolvePhenomenon(gameId: String) async throws -> PhenomenonResult
     func selectPlane(gameId: String, planeId: String) async throws
     func endGame(gameId: String, winnerUserIds: [String]?) async throws
+    func updateGameSettings(gameId: String, maxPlayers: Int?, startingLife: Int?, gameMode: String?) async throws
 }

--- a/Treachery-iOS/Treachery-iOS/Protocols/FirestoreManaging.swift
+++ b/Treachery-iOS/Treachery-iOS/Protocols/FirestoreManaging.swift
@@ -39,4 +39,5 @@ protocol FirestoreManaging {
     // Player Customization
     func updatePlayerColor(gameId: String, playerId: String, color: String?) async throws
     func updateCommanderName(gameId: String, playerId: String, name: String?) async throws
+    func updatePlayerReady(gameId: String, playerId: String, isReady: Bool) async throws
 }

--- a/Treachery/app/(app)/create-game.tsx
+++ b/Treachery/app/(app)/create-game.tsx
@@ -126,6 +126,7 @@ export default function CreateGameScreen() {
         joined_at: Timestamp.now(),
         player_color: null,
         commander_name: null,
+        is_ready: false,
       };
       await firestoreService.addPlayer(player, gameId);
 

--- a/Treachery/app/(app)/dev-test-abilities.tsx
+++ b/Treachery/app/(app)/dev-test-abilities.tsx
@@ -34,31 +34,31 @@ function buildMockPlayers(abilityType: AbilityType): Player[] {
       id: 'p1', order_id: 0, user_id: 'dev_leader', display_name: 'Aragorn',
       role: 'leader', identity_card_id: leaderCard?.id ?? null,
       life_total: 45, is_eliminated: false, is_unveiled: false,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
     },
     {
       id: 'p2', order_id: 1, user_id: 'dev_guardian', display_name: 'Gandalf',
       role: 'guardian', identity_card_id: guardianCard?.id ?? null,
       life_total: 40, is_eliminated: false, is_unveiled: false,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
     },
     {
       id: 'p3', order_id: 2, user_id: 'dev_assassin1', display_name: 'Sauron',
       role: 'assassin', identity_card_id: assassinCard1?.id ?? null,
       life_total: 35, is_eliminated: false, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
     },
     {
       id: 'p4', order_id: 3, user_id: 'dev_user', display_name: 'You (Traitor)',
       role: 'traitor', identity_card_id: ABILITY_CARD_IDS[abilityType],
       life_total: 40, is_eliminated: false, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
     },
     {
       id: 'p5', order_id: 4, user_id: 'dev_assassin2', display_name: 'Saruman',
       role: 'assassin', identity_card_id: assassinCard2?.id ?? null,
       life_total: 0, is_eliminated: true, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
     },
   ];
 }

--- a/Treachery/app/(app)/join-game.tsx
+++ b/Treachery/app/(app)/join-game.tsx
@@ -9,79 +9,38 @@ import {
   Platform,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Timestamp } from 'firebase/firestore';
-import { useAuth } from '@/hooks/useAuth';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '@/config/firebase';
 import { ErrorBanner } from '@/components/ErrorBanner';
-import * as firestoreService from '@/services/firestore';
-import { Player } from '@/models/types';
 import { trackEvent } from '@/services/analytics';
 import { colors, spacing, fonts, contentMaxWidths } from '@/constants/theme';
 import { useResponsive } from '@/hooks/useResponsive';
 
-function generateId(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 export default function JoinGameScreen() {
   const router = useRouter();
-  const { currentUserId } = useAuth();
   const { isDesktop } = useResponsive();
   const [gameCode, setGameCode] = useState('');
   const [isJoining, setIsJoining] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleJoin = async () => {
-    if (!currentUserId || gameCode.length < 4) return;
+    if (gameCode.length < 4) return;
     setIsJoining(true);
     setErrorMessage(null);
 
     try {
-      const game = await firestoreService.getGameByCode(gameCode);
-      if (!game) throw new Error('No game found with that code.');
-      if (game.state !== 'waiting') throw new Error('This game has already started.');
+      const joinGameFn = httpsCallable<
+        { gameCode: string },
+        { action: string; gameId: string }
+      >(functions, 'joinGame');
+      const result = await joinGameFn({ gameCode: gameCode.toUpperCase() });
+      const { gameId, action } = result.data;
 
-      // Use game.player_ids for checks — reading the players subcollection
-      // requires being in player_ids (Firestore security rules).
-      const playerIds = game.player_ids ?? [];
-      if (playerIds.length >= game.max_players) throw new Error('This game is full.');
-
-      // Check if already in game
-      if (playerIds.includes(currentUserId)) {
-        router.replace({
-          pathname: '/(app)/lobby/[gameId]',
-          params: { gameId: game.id, isHost: 'false' },
-        });
-        setIsJoining(false);
-        return;
-      }
-
-      const user = await firestoreService.getUser(currentUserId);
-      const player: Player = {
-        id: generateId(),
-        order_id: playerIds.length,
-        user_id: currentUserId,
-        display_name: user?.display_name ?? 'Player',
-        role: null,
-        identity_card_id: null,
-        life_total: game.starting_life,
-        is_eliminated: false,
-        is_unveiled: false,
-        joined_at: Timestamp.now(),
-        player_color: null,
-        commander_name: null,
-      };
-      await firestoreService.addPlayerIdToGame(game.id, currentUserId);
-      await firestoreService.addPlayer(player, game.id);
-
-      trackEvent('join_game');
+      trackEvent(action === 'already_joined' ? 'rejoin_game' : 'join_game');
 
       router.replace({
         pathname: '/(app)/lobby/[gameId]',
-        params: { gameId: game.id, isHost: 'false' },
+        params: { gameId, isHost: 'false' },
       });
     } catch (error: unknown) {
       setErrorMessage(error instanceof Error ? error.message : 'Failed to join game.');

--- a/Treachery/app/(app)/lobby/[gameId].tsx
+++ b/Treachery/app/(app)/lobby/[gameId].tsx
@@ -143,6 +143,10 @@ function LobbyPlayerRow({
           )}
         </View>
 
+        {item.is_ready && (
+          <Ionicons name="checkmark-circle" size={20} color="#4CAF50" style={{ marginRight: 6 }} />
+        )}
+
         {isHostPlayer && (
           <View style={styles.hostBadge}>
             <Text style={styles.hostBadgeText}>Host</Text>
@@ -209,11 +213,14 @@ export default function LobbyScreen() {
     isGameDisbanded,
     isGameStarted,
     canStartGame,
+    allPlayersReady,
     minPlayers,
     startGame,
     leaveGame,
     updatePlayerColor,
     updateCommanderName,
+    toggleReady,
+    updateGameSettings,
   } = useLobby(gameId!, isHost, currentUserId);
 
   // On web, intercept browser back button — prevent accidental lobby exit
@@ -356,6 +363,70 @@ export default function LobbyScreen() {
         <View style={styles.ornateLine} />
       </View>
 
+      {/* Game settings (host only) */}
+      {isHost && game && (
+        <View style={styles.settingsCard}>
+          <Text style={styles.settingsTitle}>GAME SETTINGS</Text>
+
+          <View style={styles.settingsRow}>
+            <Text style={styles.settingsLabel}>Max Players</Text>
+            <View style={styles.settingsStepper}>
+              <TouchableOpacity
+                onPress={() => updateGameSettings({ maxPlayers: Math.max(2, game.max_players - 1) })}
+                disabled={game.max_players <= 2}
+                accessibilityLabel="Decrease max players"
+              >
+                <Ionicons name="remove-circle-outline" size={24} color={game.max_players > 2 ? colors.primary : colors.textTertiary} />
+              </TouchableOpacity>
+              <Text style={styles.settingsValue}>{game.max_players}</Text>
+              <TouchableOpacity
+                onPress={() => updateGameSettings({ maxPlayers: Math.min(8, game.max_players + 1) })}
+                disabled={game.max_players >= 8}
+                accessibilityLabel="Increase max players"
+              >
+                <Ionicons name="add-circle-outline" size={24} color={game.max_players < 8 ? colors.primary : colors.textTertiary} />
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={styles.settingsDivider} />
+
+          <View style={styles.settingsRow}>
+            <Text style={styles.settingsLabel}>Starting Life</Text>
+            <View style={styles.settingsChips}>
+              {[20, 25, 30, 40, 50].map((life) => (
+                <TouchableOpacity
+                  key={life}
+                  style={[styles.chip, game.starting_life === life && styles.chipActive]}
+                  onPress={() => updateGameSettings({ startingLife: life })}
+                  accessibilityLabel={`Set starting life to ${life}`}
+                >
+                  <Text style={[styles.chipText, game.starting_life === life && styles.chipTextActive]}>{life}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.settingsDivider} />
+
+          <View style={styles.settingsRow}>
+            <Text style={styles.settingsLabel}>Game Mode</Text>
+            <View style={styles.settingsChips}>
+              {Object.entries(MODE_DISPLAY).map(([key, label]) => (
+                <TouchableOpacity
+                  key={key}
+                  style={[styles.chip, game.game_mode === key && styles.chipActive]}
+                  onPress={() => updateGameSettings({ gameMode: key })}
+                  accessibilityLabel={`Set game mode to ${label}`}
+                >
+                  <Text style={[styles.chipText, game.game_mode === key && styles.chipTextActive]}>{label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        </View>
+      )}
+
       {/* Player list */}
       <Text style={styles.sectionTitle}>
         Players ({players.length})
@@ -383,6 +454,32 @@ export default function LobbyScreen() {
           keyboardShouldPersistTaps="handled"
         />
       )}
+
+      {/* Ready toggle button (shown when 2+ players) */}
+      {players.length >= 2 && (() => {
+        const currentPlayer = players.find((p) => p.user_id === currentUserId);
+        const isReady = currentPlayer?.is_ready ?? false;
+        return (
+          <TouchableOpacity
+            style={[
+              styles.readyToggle,
+              isReady && styles.readyToggleActive,
+            ]}
+            onPress={toggleReady}
+            accessibilityLabel={isReady ? 'Mark as not ready' : 'Mark as ready'}
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name={isReady ? 'checkmark-circle' : 'ellipse-outline'}
+              size={20}
+              color={isReady ? '#4CAF50' : colors.textSecondary}
+            />
+            <Text style={[styles.readyToggleText, isReady && styles.readyToggleTextActive]}>
+              {isReady ? 'Ready' : 'Not Ready'}
+            </Text>
+          </TouchableOpacity>
+        );
+      })()}
 
       {!isHost && (
         <View style={styles.waitingRow}>
@@ -417,8 +514,12 @@ export default function LobbyScreen() {
               )}
             </TouchableOpacity>
 
-            {!canStartGame && players.length < minPlayers && (
-              <Text style={styles.minPlayersText}>Need at least {minPlayers} players to start</Text>
+            {!canStartGame && (
+              players.length < minPlayers ? (
+                <Text style={styles.minPlayersText}>Need at least {minPlayers} players to start</Text>
+              ) : !allPlayersReady ? (
+                <Text style={styles.minPlayersText}>All players must be ready to start</Text>
+              ) : null
             )}
           </>
         )}
@@ -534,6 +635,72 @@ const styles = StyleSheet.create({
     color: colors.primary,
     fontSize: 10,
   },
+  settingsCard: {
+    marginHorizontal: spacing.lg,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 10,
+    padding: spacing.md,
+    gap: 10,
+  },
+  settingsTitle: {
+    color: colors.textSecondary,
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+  },
+  settingsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  settingsLabel: {
+    color: colors.textSecondary,
+    fontSize: 14,
+  },
+  settingsStepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  settingsValue: {
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: '600',
+    minWidth: 24,
+    textAlign: 'center',
+  },
+  settingsChips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  chip: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  chipActive: {
+    borderColor: colors.primary,
+    backgroundColor: 'rgba(201, 168, 76, 0.15)',
+  },
+  chipText: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  chipTextActive: {
+    color: colors.primary,
+  },
+  settingsDivider: {
+    height: 1,
+    backgroundColor: colors.divider,
+  },
   sectionTitle: {
     color: colors.textSecondary,
     fontSize: 12,
@@ -647,6 +814,31 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  readyToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginHorizontal: spacing.lg,
+    marginVertical: spacing.sm,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  readyToggleActive: {
+    backgroundColor: 'rgba(76, 175, 80, 0.15)',
+    borderColor: 'rgba(76, 175, 80, 0.5)',
+  },
+  readyToggleText: {
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  readyToggleTextActive: {
+    color: '#4CAF50',
   },
   waitingRow: {
     flexDirection: 'row',

--- a/Treachery/src/hooks/useLobby.ts
+++ b/Treachery/src/hooks/useLobby.ts
@@ -14,11 +14,14 @@ interface UseLobbyReturn {
   isGameDisbanded: boolean;
   isGameStarted: boolean;
   canStartGame: boolean;
+  allPlayersReady: boolean;
   minPlayers: number;
   startGame: () => Promise<void>;
   leaveGame: (userId: string) => Promise<void>;
   updatePlayerColor: (color: string | null) => Promise<void>;
   updateCommanderName: (name: string | null) => Promise<void>;
+  toggleReady: () => Promise<void>;
+  updateGameSettings: (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => Promise<void>;
 }
 
 export function useLobby(
@@ -60,7 +63,8 @@ export function useLobby(
     game?.game_mode === 'treachery' || game?.game_mode === 'treachery_planechase';
   const minPlayers = isTreacheryMode ? MINIMUM_PLAYER_COUNT : 1;
 
-  const canStartGame = isHost && players.length >= minPlayers;
+  const allPlayersReady = players.length < 2 || players.every((p) => p.is_ready);
+  const canStartGame = isHost && players.length >= minPlayers && allPlayersReady;
 
   const startGame = useCallback(async () => {
     if (!isHost || !game) return;
@@ -123,6 +127,28 @@ export function useLobby(
     [gameId, currentPlayer],
   );
 
+  const toggleReady = useCallback(async () => {
+    if (!currentPlayer) return;
+    try {
+      await firestoreService.updatePlayerReady(gameId, currentPlayer.id, !currentPlayer.is_ready);
+    } catch (error: unknown) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to update ready status.');
+    }
+  }, [gameId, currentPlayer]);
+
+  const updateGameSettings = useCallback(
+    async (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => {
+      if (!isHost || !game) return;
+      try {
+        const fn = httpsCallable(functions, 'updateGameSettings');
+        await fn({ gameId, ...settings });
+      } catch (error: unknown) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to update settings.');
+      }
+    },
+    [isHost, game, gameId],
+  );
+
   return {
     game,
     players,
@@ -131,10 +157,13 @@ export function useLobby(
     isGameDisbanded,
     isGameStarted,
     canStartGame,
+    allPlayersReady,
     minPlayers,
     startGame,
     leaveGame,
     updatePlayerColor,
     updateCommanderName,
+    toggleReady,
+    updateGameSettings,
   };
 }

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -84,6 +84,7 @@ export interface Player {
   commander_name: string | null;
   original_identity_card_id?: string | null;
   is_face_down?: boolean;
+  is_ready: boolean;
 }
 
 export interface IdentityCard {

--- a/Treachery/src/services/firestore.ts
+++ b/Treachery/src/services/firestore.ts
@@ -244,3 +244,12 @@ export async function updateCommanderName(
   const ref = doc(db, 'games', gameId, 'players', playerId);
   await updateDoc(ref, { commander_name: name && name.trim() ? name.trim() : null });
 }
+
+export async function updatePlayerReady(
+  gameId: string,
+  playerId: string,
+  isReady: boolean,
+): Promise<void> {
+  const ref = doc(db, 'games', gameId, 'players', playerId);
+  await updateDoc(ref, { is_ready: isReady });
+}

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/CloudFunctionsRepository.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/CloudFunctionsRepository.kt
@@ -10,5 +10,7 @@ interface CloudFunctionsRepository {
     suspend fun rollPlanarDie(gameId: String): String
     suspend fun resolvePhenomenon(gameId: String): Map<String, Any?>
     suspend fun selectPlane(gameId: String, planeId: String)
+    suspend fun joinGame(gameCode: String): Map<String, Any?>
     suspend fun endGame(gameId: String, winnerUserIds: List<String>?)
+    suspend fun updateGameSettings(gameId: String, maxPlayers: Int?, startingLife: Int?, gameMode: String?)
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/CloudFunctionsRepositoryImpl.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/CloudFunctionsRepositoryImpl.kt
@@ -69,10 +69,28 @@ class CloudFunctionsRepositoryImpl @Inject constructor(
             .await()
     }
 
+    override suspend fun joinGame(gameCode: String): Map<String, Any?> {
+        val result = functions.getHttpsCallable("joinGame")
+            .call(mapOf("gameCode" to gameCode))
+            .await()
+        @Suppress("UNCHECKED_CAST")
+        return result.getData() as? Map<String, Any?> ?: emptyMap()
+    }
+
     override suspend fun endGame(gameId: String, winnerUserIds: List<String>?) {
         val data = mutableMapOf<String, Any>("gameId" to gameId)
         winnerUserIds?.let { data["winnerUserIds"] = it }
         functions.getHttpsCallable("endGame")
+            .call(data)
+            .await()
+    }
+
+    override suspend fun updateGameSettings(gameId: String, maxPlayers: Int?, startingLife: Int?, gameMode: String?) {
+        val data = mutableMapOf<String, Any>("gameId" to gameId)
+        maxPlayers?.let { data["maxPlayers"] = it }
+        startingLife?.let { data["startingLife"] = it }
+        gameMode?.let { data["gameMode"] = it }
+        functions.getHttpsCallable("updateGameSettings")
             .call(data)
             .await()
     }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepository.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepository.kt
@@ -39,4 +39,5 @@ interface FirestoreRepository {
     // Player customization
     suspend fun updatePlayerColor(gameId: String, playerId: String, color: String?)
     suspend fun updateCommanderName(gameId: String, playerId: String, name: String?)
+    suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean)
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepositoryImpl.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepositoryImpl.kt
@@ -283,4 +283,11 @@ class FirestoreRepositoryImpl @Inject constructor(
             .update(update)
             .await()
     }
+
+    override suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean) {
+        firestore.collection("games").document(gameId)
+            .collection("players").document(playerId)
+            .update(mapOf("is_ready" to isReady))
+            .await()
+    }
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/model/Player.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/model/Player.kt
@@ -16,7 +16,8 @@ data class Player(
     val playerColor: String? = null,
     val commanderName: String? = null,
     val originalIdentityCardId: String? = null,
-    val isFaceDown: Boolean = false
+    val isFaceDown: Boolean = false,
+    val isReady: Boolean = false
 ) {
     fun toMap(): Map<String, Any?> = mapOf(
         "id" to id,
@@ -32,7 +33,8 @@ data class Player(
         "player_color" to playerColor,
         "commander_name" to commanderName,
         "original_identity_card_id" to originalIdentityCardId,
-        "is_face_down" to isFaceDown
+        "is_face_down" to isFaceDown,
+        "is_ready" to isReady
     )
 
     companion object {
@@ -50,7 +52,8 @@ data class Player(
             playerColor = data["player_color"] as? String,
             commanderName = data["commander_name"] as? String,
             originalIdentityCardId = data["original_identity_card_id"] as? String,
-            isFaceDown = data["is_face_down"] as? Boolean ?: false
+            isFaceDown = data["is_face_down"] as? Boolean ?: false,
+            isReady = data["is_ready"] as? Boolean ?: false
         )
     }
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/auth/AuthViewModel.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/auth/AuthViewModel.kt
@@ -121,13 +121,13 @@ class AuthViewModel @Inject constructor(
         _isNewUser.value = false
     }
 
-    fun updateDisplayName(name: String) {
-        viewModelScope.launch {
-            try {
-                val userId = currentUserId ?: return@launch
-                val user = firestoreRepository.getUser(userId) ?: return@launch
-                firestoreRepository.updateUser(user.copy(displayName = name))
-            } catch (_: Exception) { }
+    suspend fun updateDisplayName(name: String) {
+        try {
+            val userId = currentUserId ?: return
+            val user = firestoreRepository.getUser(userId) ?: return
+            firestoreRepository.updateUser(user.copy(displayName = name))
+        } catch (e: Exception) {
+            _errorMessage.value = "Failed to save display name."
         }
     }
 

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/auth/DisplayNamePromptScreen.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/auth/DisplayNamePromptScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.solomon.treachery.ui.theme.*
+import kotlinx.coroutines.launch
 
 @Composable
 fun DisplayNamePromptScreen(
@@ -23,6 +24,7 @@ fun DisplayNamePromptScreen(
     var displayName by remember { mutableStateOf("") }
     var isSaving by remember { mutableStateOf(false) }
     var validationError by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
 
     // Pre-fill from email
     LaunchedEffect(authState) {
@@ -75,8 +77,10 @@ fun DisplayNamePromptScreen(
             MtgTextField(
                 value = displayName,
                 onValueChange = {
-                    displayName = it
-                    validationError = null
+                    if (it.length <= 30) {
+                        displayName = it
+                        validationError = null
+                    }
                 },
                 placeholder = "Display Name",
                 enabled = !isSaving,
@@ -99,9 +103,11 @@ fun DisplayNamePromptScreen(
                     }
                     validationError = null
                     isSaving = true
-                    authViewModel.updateDisplayName(trimmed)
-                    isSaving = false
-                    onContinue()
+                    scope.launch {
+                        authViewModel.updateDisplayName(trimmed)
+                        isSaving = false
+                        onContinue()
+                    }
                 },
                 enabled = !isSaving,
             )

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/home/JoinGameScreen.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/home/JoinGameScreen.kt
@@ -113,8 +113,7 @@ fun JoinGameScreen(
             MtgPrimaryButton(
                 text = if (isJoining) "Joining..." else "Join Game",
                 onClick = {
-                    val userId = currentUserId ?: return@MtgPrimaryButton
-                    viewModel.joinGame(userId, gameCode) { gameId, isHost ->
+                    viewModel.joinGame(gameCode) { gameId, isHost ->
                         onNavigateToLobby(gameId, isHost)
                     }
                 },

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/home/JoinGameViewModel.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/home/JoinGameViewModel.kt
@@ -2,21 +2,18 @@ package com.solomon.treachery.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.Timestamp
 import com.solomon.treachery.data.AnalyticsService
-import com.solomon.treachery.data.FirestoreRepository
-import com.solomon.treachery.model.*
+import com.solomon.treachery.data.CloudFunctionsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
 class JoinGameViewModel @Inject constructor(
-    private val firestoreRepository: FirestoreRepository
+    private val cloudFunctionsRepository: CloudFunctionsRepository
 ) : ViewModel() {
 
     private val _isJoining = MutableStateFlow(false)
@@ -26,7 +23,6 @@ class JoinGameViewModel @Inject constructor(
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
     fun joinGame(
-        userId: String,
         gameCode: String,
         onSuccess: (gameId: String, isHost: Boolean) -> Unit
     ) {
@@ -35,40 +31,12 @@ class JoinGameViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                val game = firestoreRepository.getGameByCode(gameCode)
-                    ?: throw IllegalStateException("No game found with that code.")
+                val result = cloudFunctionsRepository.joinGame(gameCode)
+                val gameId = result["gameId"] as? String ?: ""
+                val action = result["action"] as? String ?: "joined"
 
-                if (game.state != GameState.WAITING) {
-                    throw IllegalStateException("This game has already started.")
-                }
-
-                val existingPlayers = firestoreRepository.getPlayers(game.id)
-
-                if (existingPlayers.size >= game.maxPlayers) {
-                    throw IllegalStateException("This game is full.")
-                }
-
-                // Already in game? Just navigate
-                if (existingPlayers.any { it.userId == userId }) {
-                    onSuccess(game.id, false)
-                    _isJoining.value = false
-                    return@launch
-                }
-
-                val user = firestoreRepository.getUser(userId)
-                val player = Player(
-                    id = UUID.randomUUID().toString(),
-                    orderId = existingPlayers.size,
-                    userId = userId,
-                    displayName = user?.displayName ?: "Player",
-                    lifeTotal = game.startingLife,
-                    joinedAt = Timestamp.now()
-                )
-                firestoreRepository.addPlayer(player, game.id)
-                firestoreRepository.addPlayerIdToGame(game.id, userId)
-
-                AnalyticsService.trackEvent("join_game")
-                onSuccess(game.id, false)
+                AnalyticsService.trackEvent(if (action == "already_joined") "rejoin_game" else "join_game")
+                onSuccess(gameId, false)
             } catch (e: Exception) {
                 _errorMessage.value = e.localizedMessage ?: "Failed to join game"
             }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyScreen.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyScreen.kt
@@ -146,6 +146,21 @@ fun LobbyScreen(
 
                     OrnateDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp))
 
+                    // Game settings (host only)
+                    if (viewModel.isHost) {
+                        game?.let { g ->
+                            GameSettingsCard(
+                                maxPlayers = g.maxPlayers,
+                                startingLife = g.startingLife,
+                                gameMode = g.gameMode,
+                                onMaxPlayersChange = { viewModel.updateGameSettings(maxPlayers = it) },
+                                onStartingLifeChange = { viewModel.updateGameSettings(startingLife = it) },
+                                onGameModeChange = { viewModel.updateGameSettings(gameMode = it.value) },
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                            )
+                        }
+                    }
+
                     // Player list
                     Column(
                         modifier = Modifier
@@ -197,6 +212,40 @@ fun LobbyScreen(
                             }
                         }
 
+                        // Ready toggle button (shown when 2+ players)
+                        if (players.size >= 2) {
+                            val isReady = viewModel.currentPlayer?.isReady == true
+                            OutlinedButton(
+                                onClick = { viewModel.toggleReady() },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    containerColor = if (isReady) Color(0xFF4CAF50).copy(alpha = 0.15f) else MtgSurface
+                                ),
+                                border = ButtonDefaults.outlinedButtonBorder(enabled = true).copy(
+                                    brush = Brush.linearGradient(
+                                        if (isReady) listOf(Color(0xFF4CAF50).copy(alpha = 0.5f), Color(0xFF4CAF50).copy(alpha = 0.5f))
+                                        else listOf(MtgDivider, MtgDivider)
+                                    )
+                                ),
+                                shape = RoundedCornerShape(8.dp)
+                            ) {
+                                Icon(
+                                    if (isReady) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                                    contentDescription = null,
+                                    tint = if (isReady) Color(0xFF4CAF50) else MtgTextSecondary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    if (isReady) "Ready" else "Not Ready",
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = if (isReady) Color(0xFF4CAF50) else MtgTextPrimary
+                                )
+                            }
+                        }
+
                         if (!viewModel.isHost) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
@@ -228,14 +277,24 @@ fun LobbyScreen(
                                 enabled = viewModel.canStartGame && !isStartingGame,
                                 isLoading = isStartingGame
                             )
-                            if (!viewModel.canStartGame && players.size < viewModel.minimumPlayerCount) {
-                                Text(
-                                    "Need at least ${viewModel.minimumPlayerCount} players to start",
-                                    color = MtgTextSecondary,
-                                    fontSize = 12.sp,
-                                    modifier = Modifier.fillMaxWidth(),
-                                    textAlign = TextAlign.Center
-                                )
+                            if (!viewModel.canStartGame) {
+                                if (players.size < viewModel.minimumPlayerCount) {
+                                    Text(
+                                        "Need at least ${viewModel.minimumPlayerCount} players to start",
+                                        color = MtgTextSecondary,
+                                        fontSize = 12.sp,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textAlign = TextAlign.Center
+                                    )
+                                } else if (!viewModel.allPlayersReady) {
+                                    Text(
+                                        "All players must be ready to start",
+                                        color = MtgTextSecondary,
+                                        fontSize = 12.sp,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
                             }
                         }
 
@@ -377,6 +436,16 @@ private fun PlayerRow(
                 }
             }
 
+            if (player.isReady) {
+                Icon(
+                    Icons.Default.CheckCircle,
+                    contentDescription = "Ready",
+                    tint = Color(0xFF4CAF50),
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(4.dp))
+            }
+
             if (isHost) {
                 Text(
                     "Host",
@@ -464,6 +533,92 @@ private fun PlayerRow(
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(Icons.Default.Close, "Clear", tint = MtgTextSecondary, modifier = Modifier.size(12.dp))
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GameSettingsCard(
+    maxPlayers: Int,
+    startingLife: Int,
+    gameMode: com.solomon.treachery.model.GameMode,
+    onMaxPlayersChange: (Int) -> Unit,
+    onStartingLifeChange: (Int) -> Unit,
+    onGameModeChange: (com.solomon.treachery.model.GameMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var showLifeMenu by remember { mutableStateOf(false) }
+    var showModeMenu by remember { mutableStateOf(false) }
+
+    MtgCardFrame(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            MtgSectionHeader("Game Settings")
+
+            // Max Players
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Max Players", color = MtgTextSecondary, fontSize = 14.sp)
+                Spacer(Modifier.weight(1f))
+                IconButton(
+                    onClick = { if (maxPlayers > 2) onMaxPlayersChange(maxPlayers - 1) },
+                    enabled = maxPlayers > 2,
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Icon(Icons.Default.RemoveCircleOutline, "Decrease", tint = if (maxPlayers > 2) MtgGold else MtgTextSecondary.copy(alpha = 0.3f))
+                }
+                Text("$maxPlayers", color = MtgTextPrimary, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(24.dp), textAlign = TextAlign.Center)
+                IconButton(
+                    onClick = { if (maxPlayers < 8) onMaxPlayersChange(maxPlayers + 1) },
+                    enabled = maxPlayers < 8,
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Icon(Icons.Default.AddCircleOutline, "Increase", tint = if (maxPlayers < 8) MtgGold else MtgTextSecondary.copy(alpha = 0.3f))
+                }
+            }
+
+            HorizontalDivider(color = MtgDivider)
+
+            // Starting Life
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Starting Life", color = MtgTextSecondary, fontSize = 14.sp)
+                Spacer(Modifier.weight(1f))
+                Box {
+                    TextButton(onClick = { showLifeMenu = true }) {
+                        Text("$startingLife", color = MtgTextPrimary, fontWeight = FontWeight.SemiBold)
+                        Icon(Icons.Default.UnfoldMore, null, tint = MtgGold, modifier = Modifier.size(16.dp))
+                    }
+                    DropdownMenu(expanded = showLifeMenu, onDismissRequest = { showLifeMenu = false }) {
+                        listOf(20, 25, 30, 40, 50).forEach { life ->
+                            DropdownMenuItem(
+                                text = { Text("$life") },
+                                onClick = { onStartingLifeChange(life); showLifeMenu = false }
+                            )
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider(color = MtgDivider)
+
+            // Game Mode
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Game Mode", color = MtgTextSecondary, fontSize = 14.sp)
+                Spacer(Modifier.weight(1f))
+                Box {
+                    TextButton(onClick = { showModeMenu = true }) {
+                        Text(gameMode.displayName, color = MtgTextPrimary, fontWeight = FontWeight.SemiBold)
+                        Icon(Icons.Default.UnfoldMore, null, tint = MtgGold, modifier = Modifier.size(16.dp))
+                    }
+                    DropdownMenu(expanded = showModeMenu, onDismissRequest = { showModeMenu = false }) {
+                        com.solomon.treachery.model.GameMode.entries.forEach { mode ->
+                            DropdownMenuItem(
+                                text = { Text(mode.displayName) },
+                                onClick = { onGameModeChange(mode); showModeMenu = false }
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyViewModel.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyViewModel.kt
@@ -50,8 +50,12 @@ class LobbyViewModel @Inject constructor(
         get() {
             val g = game.value ?: return false
             val minPlayers = if (g.gameMode.includesTreachery) Role.MINIMUM_PLAYER_COUNT else 1
-            return isHost && players.value.size >= minPlayers
+            val allReady = players.value.size < 2 || players.value.all { it.isReady }
+            return isHost && players.value.size >= minPlayers && allReady
         }
+
+    val allPlayersReady: Boolean
+        get() = players.value.size < 2 || players.value.all { it.isReady }
 
     val minimumPlayerCount: Int
         get() {
@@ -129,6 +133,28 @@ class LobbyViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 firestoreRepository.updateCommanderName(gameId, player.id, name)
+            } catch (e: Exception) {
+                _errorMessage.value = e.localizedMessage
+            }
+        }
+    }
+
+    fun updateGameSettings(maxPlayers: Int? = null, startingLife: Int? = null, gameMode: String? = null) {
+        if (!isHost) return
+        viewModelScope.launch {
+            try {
+                cloudFunctionsRepository.updateGameSettings(gameId, maxPlayers, startingLife, gameMode)
+            } catch (e: Exception) {
+                _errorMessage.value = e.localizedMessage
+            }
+        }
+    }
+
+    fun toggleReady() {
+        val player = currentPlayer ?: return
+        viewModelScope.launch {
+            try {
+                firestoreRepository.updatePlayerReady(gameId, player.id, !player.isReady)
             } catch (e: Exception) {
                 _errorMessage.value = e.localizedMessage
             }

--- a/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockCloudFunctionsRepository.kt
+++ b/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockCloudFunctionsRepository.kt
@@ -76,4 +76,18 @@ class MockCloudFunctionsRepository : CloudFunctionsRepository {
         throwIfNeeded()
         endGameCalls.add(gameId to winnerUserIds)
     }
+
+    var joinGameResult: Map<String, Any?> = mapOf("action" to "joined", "gameId" to "test-game-id")
+    val joinGameCalls = mutableListOf<String>()
+    override suspend fun joinGame(gameCode: String): Map<String, Any?> {
+        throwIfNeeded()
+        joinGameCalls.add(gameCode)
+        return joinGameResult
+    }
+
+    val updateGameSettingsCalls = mutableListOf<Map<String, Any?>>()
+    override suspend fun updateGameSettings(gameId: String, maxPlayers: Int?, startingLife: Int?, gameMode: String?) {
+        throwIfNeeded()
+        updateGameSettingsCalls.add(mapOf("gameId" to gameId, "maxPlayers" to maxPlayers, "startingLife" to startingLife, "gameMode" to gameMode))
+    }
 }

--- a/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockFirestoreRepository.kt
+++ b/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockFirestoreRepository.kt
@@ -176,4 +176,10 @@ class MockFirestoreRepository : FirestoreRepository {
         throwIfNeeded()
         updateCommanderNameCalls.add(Triple(gameId, playerId, name))
     }
+
+    val updatePlayerReadyCalls = mutableListOf<Triple<String, String, Boolean>>()
+    override suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean) {
+        throwIfNeeded()
+        updatePlayerReadyCalls.add(Triple(gameId, playerId, isReady))
+    }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -289,6 +289,17 @@ exports.startGame = onCall(callableOptions, async (request) => {
     );
     const players = playersSnap.docs.map((d) => ({ ref: d.ref, ...d.data() }));
 
+    // Enforce ready-up for games with 2+ players
+    if (players.length >= 2) {
+      const notReady = players.filter((p) => p.is_ready !== true);
+      if (notReady.length > 0) {
+        throw new HttpsError(
+          "failed-precondition",
+          "All players must be ready before starting."
+        );
+      }
+    }
+
     if (includesTreachery) {
       // Validate minimum player count against role distribution
       if (players.length < 1) {
@@ -570,7 +581,7 @@ exports.joinGame = onCall(callableOptions, async (request) => {
   // Look up the game by code (outside transaction since query-by-code is safe)
   const gamesSnap = await db
     .collection("games")
-    .where("game_code", "==", gameCode.toUpperCase())
+    .where("code", "==", gameCode.toUpperCase())
     .limit(1)
     .get();
 
@@ -627,6 +638,7 @@ exports.joinGame = onCall(callableOptions, async (request) => {
       life_total: game.starting_life || 40,
       is_eliminated: false,
       is_unveiled: false,
+      is_ready: false,
       joined_at: FieldValue.serverTimestamp(),
     });
 
@@ -1322,6 +1334,70 @@ exports.endGame = onCall(callableOptions, async (request) => {
     tx.update(gameRef, update);
 
     return { action: "ended" };
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CLOUD FUNCTION: updateGameSettings
+// Host-only: update game settings (max players, starting life,
+// game mode) while game is in waiting state.
+// ════════════════════════════════════════════════════════════════
+
+exports.updateGameSettings = onCall(callableOptions, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { gameId, maxPlayers, startingLife, gameMode } = request.data;
+  if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
+
+  return db.runTransaction(async (tx) => {
+    const gameRef = db.doc(`games/${gameId}`);
+    const gameSnap = await tx.get(gameRef);
+    if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
+    const game = gameSnap.data();
+
+    if (game.host_id !== uid) {
+      throw new HttpsError("permission-denied", "Only the host can change settings.");
+    }
+    if (game.state !== "waiting") {
+      throw new HttpsError("failed-precondition", "Cannot change settings after game starts.");
+    }
+
+    const update = { last_activity_at: FieldValue.serverTimestamp() };
+
+    if (maxPlayers !== undefined) {
+      const mp = Number(maxPlayers);
+      if (mp < 2 || mp > 8) throw new HttpsError("invalid-argument", "Max players must be 2-8.");
+      update.max_players = mp;
+    }
+
+    if (startingLife !== undefined) {
+      const sl = Number(startingLife);
+      if (![20, 25, 30, 40, 50].includes(sl)) {
+        throw new HttpsError("invalid-argument", "Invalid starting life value.");
+      }
+      update.starting_life = sl;
+    }
+
+    if (gameMode !== undefined) {
+      const validModes = ["treachery", "planechase", "treachery_planechase", "none"];
+      if (!validModes.includes(gameMode)) {
+        throw new HttpsError("invalid-argument", "Invalid game mode.");
+      }
+      update.game_mode = gameMode;
+    }
+
+    tx.update(gameRef, update);
+
+    // If starting life changed, update all existing players' life totals
+    if (startingLife !== undefined) {
+      const playersSnap = await tx.get(db.collection(`games/${gameId}/players`));
+      playersSnap.docs.forEach((doc) => {
+        tx.update(doc.ref, { life_total: Number(startingLife) });
+      });
+    }
+
+    return { success: true };
   });
 });
 


### PR DESCRIPTION
## Summary

- **Fix joinGame cloud function** — field name mismatch (`game_code` → `code`) was silently breaking all game joins via the cloud function
- **Android + Web joinGame parity** — both platforms now call the transactional `joinGame` cloud function instead of racy client-side Firestore writes
- **Lobby ready-up mechanic** (all platforms) — players toggle ready status, host can only start when all are ready, server-side enforcement in `startGame`
- **Host game settings editing** (all platforms) — host can change max players (2-8), starting life (20/25/30/40/50), and game mode from the lobby via new `updateGameSettings` cloud function
- **Onboarding QA fixes** — Android `updateDisplayName` now awaited before navigation (was fire-and-forget), errors surfaced to UI (were silently swallowed), 30-char max on display name input (iOS + Android, matching web)

## Files changed (29 files across iOS, Android, Web, and Cloud Functions)

**Cloud Functions** (`functions/index.js`):
- Fixed `joinGame` field query
- Added `is_ready: false` to player creation
- Added ready-up enforcement in `startGame`
- New `updateGameSettings` callable

**iOS**: Player model, CloudFunctions, FirestoreManager, LobbyView + subviews, LobbyViewModel, DisplayNamePromptView
**Android**: Player model, repositories, JoinGameViewModel, LobbyScreen + ViewModel, AuthViewModel, DisplayNamePromptScreen, mocks
**Web**: types.ts, firestore.ts, useLobby.ts, join-game.tsx, lobby/[gameId].tsx

## Test plan

- [ ] Deploy cloud functions and verify `joinGame` finds games by code
- [ ] Test join game flow on Android and Web — should use cloud function (check Firebase logs)
- [ ] Test ready-up: toggle ready, verify checkmarks sync in real-time across clients, host can't start until all ready
- [ ] Test game settings: host changes max players/life/mode, verify reflected for all players, non-hosts can't see settings panel
- [ ] Test onboarding on Android: enter display name → Continue → verify name persists in Firestore before navigating
- [ ] Test display name max length (30 chars) on iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)