### PR TITLE
P0: Remove ready-up gating that blocks hosts from starting games

### DIFF
--- a/Treachery-iOS/Treachery-iOS/Home/LobbyBottomButtons.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyBottomButtons.swift
@@ -30,16 +30,10 @@ struct LobbyBottomButtons: View {
                 .buttonStyle(MtgPrimaryButtonStyle(isDisabled: !viewModel.canStartGame || viewModel.isStartingGame))
                 .disabled(!viewModel.canStartGame || viewModel.isStartingGame)
 
-                if !viewModel.canStartGame {
-                    if viewModel.players.count < viewModel.minimumPlayerCount {
-                        Text("Need at least \(viewModel.minimumPlayerCount) player\(viewModel.minimumPlayerCount == 1 ? "" : "s") to start")
-                            .font(.caption)
-                            .foregroundStyle(Color.mtgTextSecondary)
-                    } else if !viewModel.allPlayersReady {
-                        Text("All players must be ready to start")
-                            .font(.caption)
-                            .foregroundStyle(Color.mtgTextSecondary)
-                    }
+                if !viewModel.canStartGame && viewModel.players.count < viewModel.minimumPlayerCount {
+                    Text("Need at least \(viewModel.minimumPlayerCount) player\(viewModel.minimumPlayerCount == 1 ? "" : "s") to start")
+                        .font(.caption)
+                        .foregroundStyle(Color.mtgTextSecondary)
                 }
             }
 

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyPlayerRow.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyPlayerRow.swift
@@ -45,13 +45,6 @@ struct LobbyPlayerRow: View {
 
                 Spacer()
 
-                if player.isReady {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(Color.green)
-                        .font(.body)
-                        .transition(.scale.combined(with: .opacity))
-                }
-
                 if isHost {
                     MtgBadge(text: "Host", foregroundColor: .mtgGold, backgroundColor: Color.mtgGold.opacity(0.15), font: .caption)
                 }

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyView.swift
@@ -269,37 +269,6 @@ struct LobbyView: View {
         .padding(.horizontal)
     }
 
-    // MARK: - Ready Toggle
-
-    private var readyToggle: some View {
-        Button {
-            Task { await viewModel.toggleReady() }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: viewModel.currentPlayer?.isReady == true ? "checkmark.circle.fill" : "circle")
-                    .foregroundStyle(viewModel.currentPlayer?.isReady == true ? Color.green : Color.mtgTextSecondary)
-                Text(viewModel.currentPlayer?.isReady == true ? "Ready" : "Not Ready")
-                    .fontWeight(.semibold)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                viewModel.currentPlayer?.isReady == true
-                    ? Color.green.opacity(0.15)
-                    : Color.mtgSurface
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(
-                        viewModel.currentPlayer?.isReady == true ? Color.green.opacity(0.5) : Color.mtgDivider,
-                        lineWidth: 1
-                    )
-            )
-        }
-        .foregroundStyle(viewModel.currentPlayer?.isReady == true ? Color.green : Color.mtgTextPrimary)
-    }
-
     // MARK: - Player List
 
     private var playerListSection: some View {
@@ -356,12 +325,6 @@ struct LobbyView: View {
                     .animation(.easeInOut(duration: 0.3), value: viewModel.players.map(\.id))
                     .mtgCardFrame()
                     .padding(.horizontal)
-                }
-
-                if viewModel.players.count >= 2 {
-                    readyToggle
-                        .padding(.top, 16)
-                        .padding(.horizontal)
                 }
 
                 if !viewModel.isHost {

--- a/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/LobbyViewModel.swift
@@ -33,12 +33,7 @@ final class LobbyViewModel: ObservableObject {
     var canStartGame: Bool {
         guard let game = game else { return false }
         let minPlayers = game.gameMode.includesTreachery ? Role.minimumPlayerCount : 1
-        let allReady = players.count < 2 || players.allSatisfy { $0.isReady }
-        return isHost && players.count >= minPlayers && allReady
-    }
-
-    var allPlayersReady: Bool {
-        players.count < 2 || players.allSatisfy { $0.isReady }
+        return isHost && players.count >= minPlayers
     }
 
     var minimumPlayerCount: Int {
@@ -156,12 +151,4 @@ final class LobbyViewModel: ObservableObject {
         }
     }
 
-    func toggleReady() async {
-        guard let player = currentPlayer else { return }
-        do {
-            try await firestoreManager.updatePlayerReady(gameId: gameId, playerId: player.id, isReady: !player.isReady)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
 }

--- a/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
+++ b/Treachery-iOS/Treachery-iOS/Managers/FirestoreManager.swift
@@ -300,7 +300,4 @@ final class FirestoreManager: FirestoreManaging {
         }
     }
 
-    func updatePlayerReady(gameId: String, playerId: String, isReady: Bool) async throws {
-        try await playersCollection(gameId: gameId).document(playerId).updateData(["is_ready": isReady])
-    }
 }

--- a/Treachery-iOS/Treachery-iOS/Models/Player.swift
+++ b/Treachery-iOS/Treachery-iOS/Models/Player.swift
@@ -22,7 +22,6 @@ struct Player: Codable, Identifiable, Equatable {
     var commanderName: String?
     var originalIdentityCardId: String?
     var isFaceDown: Bool
-    var isReady: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -39,7 +38,6 @@ struct Player: Codable, Identifiable, Equatable {
         case commanderName = "commander_name"
         case originalIdentityCardId = "original_identity_card_id"
         case isFaceDown = "is_face_down"
-        case isReady = "is_ready"
     }
 
     // Custom decoder: uses decodeIfPresent for 'id' to handle documents
@@ -62,7 +60,6 @@ struct Player: Codable, Identifiable, Equatable {
         commanderName = try container.decodeIfPresent(String.self, forKey: .commanderName)
         originalIdentityCardId = try container.decodeIfPresent(String.self, forKey: .originalIdentityCardId)
         isFaceDown = try container.decodeIfPresent(Bool.self, forKey: .isFaceDown) ?? false
-        isReady = try container.decodeIfPresent(Bool.self, forKey: .isReady) ?? false
     }
 
     init(
@@ -79,8 +76,7 @@ struct Player: Codable, Identifiable, Equatable {
         playerColor: String? = nil,
         commanderName: String? = nil,
         originalIdentityCardId: String? = nil,
-        isFaceDown: Bool = false,
-        isReady: Bool = false
+        isFaceDown: Bool = false
     ) {
         self.id = id
         self.orderId = orderId
@@ -96,6 +92,5 @@ struct Player: Codable, Identifiable, Equatable {
         self.commanderName = commanderName
         self.originalIdentityCardId = originalIdentityCardId
         self.isFaceDown = isFaceDown
-        self.isReady = isReady
     }
 }

--- a/Treachery-iOS/Treachery-iOS/Protocols/FirestoreManaging.swift
+++ b/Treachery-iOS/Treachery-iOS/Protocols/FirestoreManaging.swift
@@ -39,5 +39,4 @@ protocol FirestoreManaging {
     // Player Customization
     func updatePlayerColor(gameId: String, playerId: String, color: String?) async throws
     func updateCommanderName(gameId: String, playerId: String, name: String?) async throws
-    func updatePlayerReady(gameId: String, playerId: String, isReady: Bool) async throws
 }

--- a/Treachery/app/(app)/create-game.tsx
+++ b/Treachery/app/(app)/create-game.tsx
@@ -126,7 +126,6 @@ export default function CreateGameScreen() {
         joined_at: Timestamp.now(),
         player_color: null,
         commander_name: null,
-        is_ready: false,
       };
       await firestoreService.addPlayer(player, gameId);
 

--- a/Treachery/app/(app)/dev-test-abilities.tsx
+++ b/Treachery/app/(app)/dev-test-abilities.tsx
@@ -34,31 +34,31 @@ function buildMockPlayers(abilityType: AbilityType): Player[] {
       id: 'p1', order_id: 0, user_id: 'dev_leader', display_name: 'Aragorn',
       role: 'leader', identity_card_id: leaderCard?.id ?? null,
       life_total: 45, is_eliminated: false, is_unveiled: false,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null,
     },
     {
       id: 'p2', order_id: 1, user_id: 'dev_guardian', display_name: 'Gandalf',
       role: 'guardian', identity_card_id: guardianCard?.id ?? null,
       life_total: 40, is_eliminated: false, is_unveiled: false,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null,
     },
     {
       id: 'p3', order_id: 2, user_id: 'dev_assassin1', display_name: 'Sauron',
       role: 'assassin', identity_card_id: assassinCard1?.id ?? null,
       life_total: 35, is_eliminated: false, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null,
     },
     {
       id: 'p4', order_id: 3, user_id: 'dev_user', display_name: 'You (Traitor)',
       role: 'traitor', identity_card_id: ABILITY_CARD_IDS[abilityType],
       life_total: 40, is_eliminated: false, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null,
     },
     {
       id: 'p5', order_id: 4, user_id: 'dev_assassin2', display_name: 'Saruman',
       role: 'assassin', identity_card_id: assassinCard2?.id ?? null,
       life_total: 0, is_eliminated: true, is_unveiled: true,
-      joined_at: Timestamp.now(), player_color: null, commander_name: null, is_ready: false,
+      joined_at: Timestamp.now(), player_color: null, commander_name: null,
     },
   ];
 }

--- a/Treachery/app/(app)/lobby/[gameId].tsx
+++ b/Treachery/app/(app)/lobby/[gameId].tsx
@@ -143,10 +143,6 @@ function LobbyPlayerRow({
           )}
         </View>
 
-        {item.is_ready && (
-          <Ionicons name="checkmark-circle" size={20} color="#4CAF50" style={{ marginRight: 6 }} />
-        )}
-
         {isHostPlayer && (
           <View style={styles.hostBadge}>
             <Text style={styles.hostBadgeText}>Host</Text>
@@ -213,13 +209,11 @@ export default function LobbyScreen() {
     isGameDisbanded,
     isGameStarted,
     canStartGame,
-    allPlayersReady,
     minPlayers,
     startGame,
     leaveGame,
     updatePlayerColor,
     updateCommanderName,
-    toggleReady,
     updateGameSettings,
   } = useLobby(gameId!, isHost, currentUserId);
 
@@ -455,32 +449,6 @@ export default function LobbyScreen() {
         />
       )}
 
-      {/* Ready toggle button (shown when 2+ players) */}
-      {players.length >= 2 && (() => {
-        const currentPlayer = players.find((p) => p.user_id === currentUserId);
-        const isReady = currentPlayer?.is_ready ?? false;
-        return (
-          <TouchableOpacity
-            style={[
-              styles.readyToggle,
-              isReady && styles.readyToggleActive,
-            ]}
-            onPress={toggleReady}
-            accessibilityLabel={isReady ? 'Mark as not ready' : 'Mark as ready'}
-            accessibilityRole="button"
-          >
-            <Ionicons
-              name={isReady ? 'checkmark-circle' : 'ellipse-outline'}
-              size={20}
-              color={isReady ? '#4CAF50' : colors.textSecondary}
-            />
-            <Text style={[styles.readyToggleText, isReady && styles.readyToggleTextActive]}>
-              {isReady ? 'Ready' : 'Not Ready'}
-            </Text>
-          </TouchableOpacity>
-        );
-      })()}
-
       {!isHost && (
         <View style={styles.waitingRow}>
           <ActivityIndicator size="small" color={colors.primary} />
@@ -514,12 +482,8 @@ export default function LobbyScreen() {
               )}
             </TouchableOpacity>
 
-            {!canStartGame && (
-              players.length < minPlayers ? (
-                <Text style={styles.minPlayersText}>Need at least {minPlayers} players to start</Text>
-              ) : !allPlayersReady ? (
-                <Text style={styles.minPlayersText}>All players must be ready to start</Text>
-              ) : null
+            {!canStartGame && players.length < minPlayers && (
+              <Text style={styles.minPlayersText}>Need at least {minPlayers} players to start</Text>
             )}
           </>
         )}
@@ -814,31 +778,6 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  readyToggle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    marginHorizontal: spacing.lg,
-    marginVertical: spacing.sm,
-    paddingVertical: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-  },
-  readyToggleActive: {
-    backgroundColor: 'rgba(76, 175, 80, 0.15)',
-    borderColor: 'rgba(76, 175, 80, 0.5)',
-  },
-  readyToggleText: {
-    color: colors.text,
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  readyToggleTextActive: {
-    color: '#4CAF50',
   },
   waitingRow: {
     flexDirection: 'row',

--- a/Treachery/src/hooks/useLobby.ts
+++ b/Treachery/src/hooks/useLobby.ts
@@ -14,13 +14,11 @@ interface UseLobbyReturn {
   isGameDisbanded: boolean;
   isGameStarted: boolean;
   canStartGame: boolean;
-  allPlayersReady: boolean;
   minPlayers: number;
   startGame: () => Promise<void>;
   leaveGame: (userId: string) => Promise<void>;
   updatePlayerColor: (color: string | null) => Promise<void>;
   updateCommanderName: (name: string | null) => Promise<void>;
-  toggleReady: () => Promise<void>;
   updateGameSettings: (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => Promise<void>;
 }
 
@@ -63,8 +61,7 @@ export function useLobby(
     game?.game_mode === 'treachery' || game?.game_mode === 'treachery_planechase';
   const minPlayers = isTreacheryMode ? MINIMUM_PLAYER_COUNT : 1;
 
-  const allPlayersReady = players.length < 2 || players.every((p) => p.is_ready);
-  const canStartGame = isHost && players.length >= minPlayers && allPlayersReady;
+  const canStartGame = isHost && players.length >= minPlayers;
 
   const startGame = useCallback(async () => {
     if (!isHost || !game) return;
@@ -127,15 +124,6 @@ export function useLobby(
     [gameId, currentPlayer],
   );
 
-  const toggleReady = useCallback(async () => {
-    if (!currentPlayer) return;
-    try {
-      await firestoreService.updatePlayerReady(gameId, currentPlayer.id, !currentPlayer.is_ready);
-    } catch (error: unknown) {
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to update ready status.');
-    }
-  }, [gameId, currentPlayer]);
-
   const updateGameSettings = useCallback(
     async (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => {
       if (!isHost || !game) return;
@@ -157,13 +145,11 @@ export function useLobby(
     isGameDisbanded,
     isGameStarted,
     canStartGame,
-    allPlayersReady,
     minPlayers,
     startGame,
     leaveGame,
     updatePlayerColor,
     updateCommanderName,
-    toggleReady,
     updateGameSettings,
   };
 }

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -84,7 +84,6 @@ export interface Player {
   commander_name: string | null;
   original_identity_card_id?: string | null;
   is_face_down?: boolean;
-  is_ready: boolean;
 }
 
 export interface IdentityCard {

--- a/Treachery/src/services/firestore.ts
+++ b/Treachery/src/services/firestore.ts
@@ -245,11 +245,3 @@ export async function updateCommanderName(
   await updateDoc(ref, { commander_name: name && name.trim() ? name.trim() : null });
 }
 
-export async function updatePlayerReady(
-  gameId: string,
-  playerId: string,
-  isReady: boolean,
-): Promise<void> {
-  const ref = doc(db, 'games', gameId, 'players', playerId);
-  await updateDoc(ref, { is_ready: isReady });
-}

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepository.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepository.kt
@@ -39,5 +39,4 @@ interface FirestoreRepository {
     // Player customization
     suspend fun updatePlayerColor(gameId: String, playerId: String, color: String?)
     suspend fun updateCommanderName(gameId: String, playerId: String, name: String?)
-    suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean)
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepositoryImpl.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/data/FirestoreRepositoryImpl.kt
@@ -284,10 +284,4 @@ class FirestoreRepositoryImpl @Inject constructor(
             .await()
     }
 
-    override suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean) {
-        firestore.collection("games").document(gameId)
-            .collection("players").document(playerId)
-            .update(mapOf("is_ready" to isReady))
-            .await()
-    }
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/model/Player.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/model/Player.kt
@@ -16,8 +16,7 @@ data class Player(
     val playerColor: String? = null,
     val commanderName: String? = null,
     val originalIdentityCardId: String? = null,
-    val isFaceDown: Boolean = false,
-    val isReady: Boolean = false
+    val isFaceDown: Boolean = false
 ) {
     fun toMap(): Map<String, Any?> = mapOf(
         "id" to id,
@@ -33,8 +32,7 @@ data class Player(
         "player_color" to playerColor,
         "commander_name" to commanderName,
         "original_identity_card_id" to originalIdentityCardId,
-        "is_face_down" to isFaceDown,
-        "is_ready" to isReady
+        "is_face_down" to isFaceDown
     )
 
     companion object {
@@ -52,8 +50,7 @@ data class Player(
             playerColor = data["player_color"] as? String,
             commanderName = data["commander_name"] as? String,
             originalIdentityCardId = data["original_identity_card_id"] as? String,
-            isFaceDown = data["is_face_down"] as? Boolean ?: false,
-            isReady = data["is_ready"] as? Boolean ?: false
+            isFaceDown = data["is_face_down"] as? Boolean ?: false
         )
     }
 }

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyScreen.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyScreen.kt
@@ -212,40 +212,6 @@ fun LobbyScreen(
                             }
                         }
 
-                        // Ready toggle button (shown when 2+ players)
-                        if (players.size >= 2) {
-                            val isReady = viewModel.currentPlayer?.isReady == true
-                            OutlinedButton(
-                                onClick = { viewModel.toggleReady() },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                                colors = ButtonDefaults.outlinedButtonColors(
-                                    containerColor = if (isReady) Color(0xFF4CAF50).copy(alpha = 0.15f) else MtgSurface
-                                ),
-                                border = ButtonDefaults.outlinedButtonBorder(enabled = true).copy(
-                                    brush = Brush.linearGradient(
-                                        if (isReady) listOf(Color(0xFF4CAF50).copy(alpha = 0.5f), Color(0xFF4CAF50).copy(alpha = 0.5f))
-                                        else listOf(MtgDivider, MtgDivider)
-                                    )
-                                ),
-                                shape = RoundedCornerShape(8.dp)
-                            ) {
-                                Icon(
-                                    if (isReady) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
-                                    contentDescription = null,
-                                    tint = if (isReady) Color(0xFF4CAF50) else MtgTextSecondary,
-                                    modifier = Modifier.size(20.dp)
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(
-                                    if (isReady) "Ready" else "Not Ready",
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = if (isReady) Color(0xFF4CAF50) else MtgTextPrimary
-                                )
-                            }
-                        }
-
                         if (!viewModel.isHost) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
@@ -277,24 +243,14 @@ fun LobbyScreen(
                                 enabled = viewModel.canStartGame && !isStartingGame,
                                 isLoading = isStartingGame
                             )
-                            if (!viewModel.canStartGame) {
-                                if (players.size < viewModel.minimumPlayerCount) {
-                                    Text(
-                                        "Need at least ${viewModel.minimumPlayerCount} players to start",
-                                        color = MtgTextSecondary,
-                                        fontSize = 12.sp,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        textAlign = TextAlign.Center
-                                    )
-                                } else if (!viewModel.allPlayersReady) {
-                                    Text(
-                                        "All players must be ready to start",
-                                        color = MtgTextSecondary,
-                                        fontSize = 12.sp,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        textAlign = TextAlign.Center
-                                    )
-                                }
+                            if (!viewModel.canStartGame && players.size < viewModel.minimumPlayerCount) {
+                                Text(
+                                    "Need at least ${viewModel.minimumPlayerCount} players to start",
+                                    color = MtgTextSecondary,
+                                    fontSize = 12.sp,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    textAlign = TextAlign.Center
+                                )
                             }
                         }
 
@@ -434,16 +390,6 @@ private fun PlayerRow(
                         color = MtgTextSecondary
                     )
                 }
-            }
-
-            if (player.isReady) {
-                Icon(
-                    Icons.Default.CheckCircle,
-                    contentDescription = "Ready",
-                    tint = Color(0xFF4CAF50),
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(Modifier.width(4.dp))
             }
 
             if (isHost) {

--- a/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyViewModel.kt
+++ b/TreacheryAndroid/app/src/main/java/com/solomon/treachery/ui/lobby/LobbyViewModel.kt
@@ -50,12 +50,8 @@ class LobbyViewModel @Inject constructor(
         get() {
             val g = game.value ?: return false
             val minPlayers = if (g.gameMode.includesTreachery) Role.MINIMUM_PLAYER_COUNT else 1
-            val allReady = players.value.size < 2 || players.value.all { it.isReady }
-            return isHost && players.value.size >= minPlayers && allReady
+            return isHost && players.value.size >= minPlayers
         }
-
-    val allPlayersReady: Boolean
-        get() = players.value.size < 2 || players.value.all { it.isReady }
 
     val minimumPlayerCount: Int
         get() {
@@ -150,14 +146,4 @@ class LobbyViewModel @Inject constructor(
         }
     }
 
-    fun toggleReady() {
-        val player = currentPlayer ?: return
-        viewModelScope.launch {
-            try {
-                firestoreRepository.updatePlayerReady(gameId, player.id, !player.isReady)
-            } catch (e: Exception) {
-                _errorMessage.value = e.localizedMessage
-            }
-        }
-    }
 }

--- a/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockFirestoreRepository.kt
+++ b/TreacheryAndroid/app/src/test/java/com/solomon/treachery/mocks/MockFirestoreRepository.kt
@@ -177,9 +177,4 @@ class MockFirestoreRepository : FirestoreRepository {
         updateCommanderNameCalls.add(Triple(gameId, playerId, name))
     }
 
-    val updatePlayerReadyCalls = mutableListOf<Triple<String, String, Boolean>>()
-    override suspend fun updatePlayerReady(gameId: String, playerId: String, isReady: Boolean) {
-        throwIfNeeded()
-        updatePlayerReadyCalls.add(Triple(gameId, playerId, isReady))
-    }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -289,17 +289,6 @@ exports.startGame = onCall(callableOptions, async (request) => {
     );
     const players = playersSnap.docs.map((d) => ({ ref: d.ref, ...d.data() }));
 
-    // Enforce ready-up for games with 2+ players
-    if (players.length >= 2) {
-      const notReady = players.filter((p) => p.is_ready !== true);
-      if (notReady.length > 0) {
-        throw new HttpsError(
-          "failed-precondition",
-          "All players must be ready before starting."
-        );
-      }
-    }
-
     if (includesTreachery) {
       // Validate minimum player count against role distribution
       if (players.length < 1) {
@@ -638,7 +627,6 @@ exports.joinGame = onCall(callableOptions, async (request) => {
       life_total: game.starting_life || 40,
       is_eliminated: false,
       is_unveiled: false,
-      is_ready: false,
       joined_at: FieldValue.serverTimestamp(),
     });
 


### PR DESCRIPTION
## Summary

- **P0 bug**: hosts cannot start 2+ player games. The host is created with `is_ready=false`, and most hosts don't realize the ready toggle applies to them, so the Start Game button stays disabled forever.
- Removes the ready-up feature entirely across cloud function, iOS, web, and Android — no enforcement, no toggle UI, no `is_ready` field on Player. Hosts can now start any game with ≥ minimum players, no extra step.
- Existing `is_ready` fields on Firestore docs are harmless — nothing reads them anymore.

## Notes

- Cloud function deploy unblocks new web users immediately.
- Mobile users on currently-shipped builds will still see the ready toggle and a disabled start button until they update — the client-side gate runs before the cloud function is called. Workaround for them is to toggle ready manually.

## Test plan

- [ ] Web: create game, second player joins, host can hit Start Game with no ready toggle visible
- [ ] Cloud function: `startGame` succeeds for a 2+ player game where `is_ready` is unset/false on docs
- [ ] iOS build: smoke test create + join + start
- [ ] Android build: smoke test create + join + start

🤖 Generated with [Claude Code](https://claude.com/claude-code)