### PR TITLE
Add max traitor rarity setting for the random pool

### DIFF
--- a/Treachery/app/(app)/create-game.tsx
+++ b/Treachery/app/(app)/create-game.tsx
@@ -13,8 +13,13 @@ import { Timestamp } from 'firebase/firestore';
 import { useAuth } from '@/hooks/useAuth';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import * as firestoreService from '@/services/firestore';
-import { CODE_CHARACTERS } from '@/constants/roles';
-import { Game, GameMode, Player } from '@/models/types';
+import {
+  CODE_CHARACTERS,
+  DEFAULT_MAX_TRAITOR_RARITY,
+  RARITY_DISPLAY_NAMES,
+  TRAITOR_RARITY_OPTIONS,
+} from '@/constants/roles';
+import { Game, GameMode, Player, Rarity } from '@/models/types';
 import { trackEvent } from '@/services/analytics';
 import { colors, spacing, fontSize, contentMaxWidths } from '@/constants/theme';
 import { useResponsive } from '@/hooks/useResponsive';
@@ -49,6 +54,7 @@ export default function CreateGameScreen() {
   const [gameMode, setGameMode] = useState<GameMode>('treachery');
   const [useOwnDeck, setUseOwnDeck] = useState(false);
   const [startingLife, setStartingLife] = useState(40);
+  const [maxTraitorRarity, setMaxTraitorRarity] = useState<Rarity>(DEFAULT_MAX_TRAITOR_RARITY);
   const [isCreating, setIsCreating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -97,6 +103,7 @@ export default function CreateGameScreen() {
         created_at: Timestamp.now(),
         last_activity_at: Timestamp.now(),
         game_mode: gameMode,
+        ...(hasTreachery ? { max_traitor_rarity: maxTraitorRarity } : {}),
         ...(hasPlanechase
           ? {
               planechase: {
@@ -168,6 +175,40 @@ export default function CreateGameScreen() {
           ))}
         </View>
       </View>
+
+      {/* Max traitor rarity selector for treachery modes */}
+      {hasTreachery && (
+        <View style={styles.section}>
+          <Text style={styles.sectionHeader}>Max Traitor Rarity</Text>
+          <View style={styles.modeRow}>
+            {TRAITOR_RARITY_OPTIONS.map((rarity) => (
+              <TouchableOpacity
+                key={rarity}
+                style={[
+                  styles.modeButton,
+                  maxTraitorRarity === rarity && styles.modeButtonSelected,
+                ]}
+                onPress={() => setMaxTraitorRarity(rarity)}
+                accessibilityLabel={`Max traitor rarity ${RARITY_DISPLAY_NAMES[rarity]}`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: maxTraitorRarity === rarity }}
+              >
+                <Text
+                  style={[
+                    styles.modeButtonText,
+                    maxTraitorRarity === rarity && styles.modeButtonTextSelected,
+                  ]}
+                >
+                  {RARITY_DISPLAY_NAMES[rarity]}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text style={styles.sectionCaption}>
+            Traitor identities up to this rarity can appear in the random pool.
+          </Text>
+        </View>
+      )}
 
       {/* Own deck toggle for planechase */}
       {hasPlanechase && (
@@ -252,6 +293,11 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 1.5,
+  },
+  sectionCaption: {
+    color: colors.textTertiary,
+    fontSize: fontSize.sm,
+    fontStyle: 'italic',
   },
   modeRow: {
     flexDirection: 'row',

--- a/Treachery/app/(app)/lobby/[gameId].tsx
+++ b/Treachery/app/(app)/lobby/[gameId].tsx
@@ -22,6 +22,11 @@ import { ErrorBanner } from '@/components/ErrorBanner';
 import { LoadingScreen } from '@/components/LoadingScreen';
 import { ConnectionBanner } from '@/components/ConnectionBanner';
 import { Player } from '@/models/types';
+import {
+  DEFAULT_MAX_TRAITOR_RARITY,
+  RARITY_DISPLAY_NAMES,
+  TRAITOR_RARITY_OPTIONS,
+} from '@/constants/roles';
 import { colors, spacing, fonts, PLAYER_COLORS, contentMaxWidths } from '@/constants/theme';
 import { useResponsive } from '@/hooks/useResponsive';
 
@@ -418,6 +423,36 @@ export default function LobbyScreen() {
               ))}
             </View>
           </View>
+
+          {/* Max traitor rarity — only meaningful in treachery modes */}
+          {((game.game_mode ?? 'treachery') === 'treachery' ||
+            game.game_mode === 'treachery_planechase') && (
+            <>
+              <View style={styles.settingsDivider} />
+              <View style={styles.settingsRow}>
+                <Text style={styles.settingsLabel}>Max Traitor Rarity</Text>
+                <View style={styles.settingsChips}>
+                  {TRAITOR_RARITY_OPTIONS.map((rarity) => {
+                    const active =
+                      (game.max_traitor_rarity ?? DEFAULT_MAX_TRAITOR_RARITY) === rarity;
+                    return (
+                      <TouchableOpacity
+                        key={rarity}
+                        style={[styles.chip, active && styles.chipActive]}
+                        onPress={() => updateGameSettings({ maxTraitorRarity: rarity })}
+                        accessibilityLabel={`Set max traitor rarity to ${RARITY_DISPLAY_NAMES[rarity]}`}
+                        accessibilityRole="button"
+                      >
+                        <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                          {RARITY_DISPLAY_NAMES[rarity]}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              </View>
+            </>
+          )}
         </View>
       )}
 

--- a/Treachery/e2e/helpers.ts
+++ b/Treachery/e2e/helpers.ts
@@ -312,6 +312,26 @@ export function playersWithRole(players: PlayerHandle[], role: Role): PlayerHand
 }
 
 /**
+ * Read the game doc itself using one of the authenticated browser contexts.
+ * Useful for asserting host settings (e.g. max_traitor_rarity) persisted.
+ */
+export async function fetchGameDoc(
+  page: Page,
+  gameId: string,
+): Promise<(Record<string, unknown> & { max_traitor_rarity?: string }) | null> {
+  return page.evaluate(
+    async ({ gameId }) => {
+      const e2e = (window as unknown as {
+        __e2e?: { fetchGame: (gid: string) => Promise<unknown> };
+      }).__e2e;
+      if (!e2e) throw new Error('window.__e2e missing');
+      return e2e.fetchGame(gameId);
+    },
+    { gameId },
+  ) as Promise<(Record<string, unknown> & { max_traitor_rarity?: string }) | null>;
+}
+
+/**
  * Read all player docs from `/games/{gameId}/players` using one of the
  * authenticated browser contexts. Useful for asserting on identity-card and
  * is_face_down state after an ability resolves.

--- a/Treachery/e2e/traitor-rarity.spec.ts
+++ b/Treachery/e2e/traitor-rarity.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import {
+  signInAsGuest,
+  hostCreateGame,
+  guestJoinGame,
+  fetchGameDoc,
+  fetchPlayerDocs,
+} from './helpers';
+
+/**
+ * Max traitor rarity cap — exercises the real (unseeded) startGame path.
+ *
+ * The host caps the traitor pool at Uncommon via the lobby settings row
+ * (updateGameSettings cloud function), then starts a 4-player game. The
+ * assigned traitor must be one of the four uncommon traitor identities.
+ *
+ * Kept in sync with functions/identityCards.json by the "Traitor Rarity Cap"
+ * suite in functions/test/game-logic.test.js, which derives these from data.
+ */
+const UNCOMMON_TRAITOR_IDS = [
+  'traitor_01', // The Banisher
+  'traitor_04', // The Gatekeeper
+  'traitor_05', // The Grenadier
+  'traitor_08', // The Oneiromancer
+];
+
+test('host caps traitor rarity at Uncommon and the assigned traitor respects it', async ({
+  browser,
+}) => {
+  const contexts = await Promise.all(
+    Array.from({ length: 4 }, () => browser.newContext()),
+  );
+  const [host, guest1, guest2, guest3] = await Promise.all(
+    contexts.map((ctx) => ctx.newPage()),
+  );
+
+  await Promise.all([host, guest1, guest2, guest3].map((p) => signInAsGuest(p)));
+
+  const { gameId, code } = await hostCreateGame(host);
+
+  // The create screen defaults the cap to Special (all traitors) and writes
+  // it onto the game doc for treachery-mode games.
+  await expect
+    .poll(async () => (await fetchGameDoc(host, gameId))?.max_traitor_rarity)
+    .toBe('special');
+
+  // Host tightens the cap to Uncommon from the lobby settings.
+  await host
+    .getByRole('button', { name: 'Set max traitor rarity to Uncommon' })
+    .click();
+  await expect
+    .poll(async () => (await fetchGameDoc(host, gameId))?.max_traitor_rarity)
+    .toBe('uncommon');
+
+  await Promise.all([guest1, guest2, guest3].map((p) => guestJoinGame(p, code)));
+  await expect(host.getByText('Players (4)')).toBeVisible();
+
+  await expect(host.getByRole('button', { name: 'Start game' })).toBeEnabled();
+  await host.getByRole('button', { name: 'Start game' }).click();
+
+  await Promise.all(
+    [host, guest1, guest2, guest3].map((p) =>
+      expect(p).toHaveURL(/\/game\//, { timeout: 20_000 }),
+    ),
+  );
+
+  // A 4-player game seats exactly one traitor; their card must be uncommon.
+  const players = await fetchPlayerDocs(host, gameId);
+  const traitors = players.filter((p) => p.role === 'traitor');
+  expect(traitors).toHaveLength(1);
+  expect(UNCOMMON_TRAITOR_IDS).toContain(traitors[0].identity_card_id);
+});

--- a/Treachery/src/config/firebase.ts
+++ b/Treachery/src/config/firebase.ts
@@ -1,6 +1,13 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth, connectAuthEmulator } from 'firebase/auth';
-import { collection, getDocs, getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  getFirestore,
+  connectFirestoreEmulator,
+} from 'firebase/firestore';
 import { getFunctions, connectFunctionsEmulator, httpsCallable } from 'firebase/functions';
 
 const useEmulator = process.env.EXPO_PUBLIC_USE_EMULATOR === 'true';
@@ -40,6 +47,12 @@ if (useEmulator) {
       fetchPlayers: async (gameId: string) => {
         const snap = await getDocs(collection(db, `games/${gameId}/players`));
         return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+      },
+      // Reads the game doc itself — used to assert host settings persisted
+      // (e.g. max_traitor_rarity) before the game starts.
+      fetchGame: async (gameId: string) => {
+        const snap = await getDoc(doc(db, `games/${gameId}`));
+        return snap.exists() ? { id: snap.id, ...snap.data() } : null;
       },
     };
   }

--- a/Treachery/src/constants/roles.ts
+++ b/Treachery/src/constants/roles.ts
@@ -1,4 +1,4 @@
-import { Role } from '@/models/types';
+import { Rarity, Role } from '@/models/types';
 
 export const ROLE_DISPLAY_NAMES: Record<Role, string> = {
   leader: 'Leader',
@@ -34,6 +34,12 @@ export const RARITY_COLORS: Record<string, string> = {
   mythic: '#d4943c',
   special: '#9c4cc9',
 };
+
+// Escalating rarity tiers for the max-traitor-rarity game setting.
+// Choosing a tier allows all traitor identities at or below it;
+// 'special' (the default) allows every traitor.
+export const TRAITOR_RARITY_OPTIONS: Rarity[] = ['uncommon', 'rare', 'mythic', 'special'];
+export const DEFAULT_MAX_TRAITOR_RARITY: Rarity = 'special';
 
 export interface RoleDistribution {
   leaders: number;

--- a/Treachery/src/hooks/useLobby.ts
+++ b/Treachery/src/hooks/useLobby.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { httpsCallable } from 'firebase/functions';
-import { Game, Player } from '@/models/types';
+import { Game, Player, Rarity } from '@/models/types';
 import * as firestoreService from '@/services/firestore';
 import { functions } from '@/config/firebase';
 import { MINIMUM_PLAYER_COUNT } from '@/constants/roles';
@@ -19,7 +19,12 @@ interface UseLobbyReturn {
   leaveGame: (userId: string) => Promise<void>;
   updatePlayerColor: (color: string | null) => Promise<void>;
   updateCommanderName: (name: string | null) => Promise<void>;
-  updateGameSettings: (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => Promise<void>;
+  updateGameSettings: (settings: {
+    maxPlayers?: number;
+    startingLife?: number;
+    gameMode?: string;
+    maxTraitorRarity?: Rarity;
+  }) => Promise<void>;
 }
 
 export function useLobby(
@@ -125,7 +130,12 @@ export function useLobby(
   );
 
   const updateGameSettings = useCallback(
-    async (settings: { maxPlayers?: number; startingLife?: number; gameMode?: string }) => {
+    async (settings: {
+      maxPlayers?: number;
+      startingLife?: number;
+      gameMode?: string;
+      maxTraitorRarity?: Rarity;
+    }) => {
       if (!isHost || !game) return;
       try {
         const fn = httpsCallable(functions, 'updateGameSettings');

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -67,6 +67,9 @@ export interface Game {
   game_mode?: GameMode;
   planechase?: PlanechaseState;
   winner_user_ids?: string[];
+  // Caps which traitor identities can appear in startGame's random pool.
+  // Absent means no cap ('special' — all traitors allowed).
+  max_traitor_rarity?: Rarity;
 }
 
 export interface Player {

--- a/functions/index.js
+++ b/functions/index.js
@@ -85,6 +85,28 @@ function getCardsForRole(role) {
   return CARDS.filter((c) => c.role === role);
 }
 
+// ── Traitor Rarity Cap ──
+// Escalating tiers; "special" marks the four table-warping traitors
+// (Metamorph, Puppet Master, Treacherous Masochist, Wearer of Masks).
+// A game's max_traitor_rarity caps which traitor identities can be
+// randomly assigned in startGame; absent/unknown values mean no cap.
+
+const RARITY_ORDER = { uncommon: 1, rare: 2, mythic: 3, special: 4 };
+
+function isValidRarity(value) {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(RARITY_ORDER, value)
+  );
+}
+
+function getTraitorPool(maxRarity) {
+  const traitors = getCardsForRole("traitor");
+  if (!isValidRarity(maxRarity)) return traitors;
+  const cap = RARITY_ORDER[maxRarity];
+  return traitors.filter((c) => RARITY_ORDER[c.rarity] <= cap);
+}
+
 function _getCard(id) {
   return CARDS.find((c) => c.id === id);
 }
@@ -368,7 +390,11 @@ exports.startGame = onCall(callableOptions, async (request) => {
 
         for (let i = 0; i < players.length; i++) {
           const role = shuffledRoles[i];
-          const availableCards = getCardsForRole(role).filter(
+          const rolePool =
+            role === "traitor"
+              ? getTraitorPool(game.max_traitor_rarity)
+              : getCardsForRole(role);
+          const availableCards = rolePool.filter(
             (c) => !usedCardIds.has(c.id)
           );
 
@@ -1407,7 +1433,7 @@ exports.updateGameSettings = onCall(callableOptions, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) throw new HttpsError("unauthenticated", "Must be signed in.");
 
-  const { gameId, maxPlayers, startingLife, gameMode } = request.data;
+  const { gameId, maxPlayers, startingLife, gameMode, maxTraitorRarity } = request.data;
   if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
 
   return db.runTransaction(async (tx) => {
@@ -1445,6 +1471,13 @@ exports.updateGameSettings = onCall(callableOptions, async (request) => {
         throw new HttpsError("invalid-argument", "Invalid game mode.");
       }
       update.game_mode = gameMode;
+    }
+
+    if (maxTraitorRarity !== undefined) {
+      if (!isValidRarity(maxTraitorRarity)) {
+        throw new HttpsError("invalid-argument", "Invalid max traitor rarity.");
+      }
+      update.max_traitor_rarity = maxTraitorRarity;
     }
 
     tx.update(gameRef, update);

--- a/functions/test/game-logic.test.js
+++ b/functions/test/game-logic.test.js
@@ -28,6 +28,23 @@ function getCardsForRole(role) {
   return CARDS.filter((c) => c.role === role);
 }
 
+// Mirrors the traitor rarity cap in index.js
+const RARITY_ORDER = { uncommon: 1, rare: 2, mythic: 3, special: 4 };
+
+function isValidRarity(value) {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(RARITY_ORDER, value)
+  );
+}
+
+function getTraitorPool(maxRarity) {
+  const traitors = getCardsForRole("traitor");
+  if (!isValidRarity(maxRarity)) return traitors;
+  const cap = RARITY_ORDER[maxRarity];
+  return traitors.filter((c) => RARITY_ORDER[c.rarity] <= cap);
+}
+
 function getRoleDistribution(playerCount) {
   const table = {
     1: { leaders: 1, guardians: 0, assassins: 0, traitors: 0 },
@@ -813,6 +830,129 @@ suite("Role Assignment — Full Simulation", () => {
           usedCardIds.add(card.id);
         }
       }
+    }
+  });
+});
+
+suite("Traitor Rarity Cap", () => {
+  const allTraitors = getCardsForRole("traitor");
+
+  test("every traitor card has a known rarity tier", () => {
+    for (const card of allTraitors) {
+      assert.ok(
+        RARITY_ORDER[card.rarity],
+        `Traitor ${card.id} (${card.name}) has unknown rarity: ${card.rarity}`
+      );
+    }
+  });
+
+  test("no cap (undefined) returns the full traitor pool", () => {
+    assert.strictEqual(getTraitorPool(undefined).length, allTraitors.length);
+  });
+
+  test("unknown cap value returns the full traitor pool (graceful fallback)", () => {
+    assert.strictEqual(getTraitorPool("bogus").length, allTraitors.length);
+    assert.strictEqual(getTraitorPool(null).length, allTraitors.length);
+    // Prototype-chain keys must not be treated as valid tiers
+    assert.strictEqual(getTraitorPool("constructor").length, allTraitors.length);
+    assert.strictEqual(getTraitorPool("hasOwnProperty").length, allTraitors.length);
+  });
+
+  test("'special' cap includes every traitor", () => {
+    assert.strictEqual(getTraitorPool("special").length, allTraitors.length);
+  });
+
+  test("pool sizes shrink monotonically as the cap tightens", () => {
+    const uncommon = getTraitorPool("uncommon").length;
+    const rare = getTraitorPool("rare").length;
+    const mythic = getTraitorPool("mythic").length;
+    const special = getTraitorPool("special").length;
+    assert.ok(
+      uncommon <= rare && rare <= mythic && mythic <= special,
+      `Pools not monotonic: ${uncommon}/${rare}/${mythic}/${special}`
+    );
+  });
+
+  test("current data: pool sizes are 4 (uncommon), 7 (rare), 9 (mythic), 13 (special)", () => {
+    assert.strictEqual(getTraitorPool("uncommon").length, 4);
+    assert.strictEqual(getTraitorPool("rare").length, 7);
+    assert.strictEqual(getTraitorPool("mythic").length, 9);
+    assert.strictEqual(getTraitorPool("special").length, 13);
+  });
+
+  test("capped pool never contains a card above the cap", () => {
+    for (const cap of ["uncommon", "rare", "mythic", "special"]) {
+      for (const card of getTraitorPool(cap)) {
+        assert.ok(
+          RARITY_ORDER[card.rarity] <= RARITY_ORDER[cap],
+          `Cap '${cap}' pool contains ${card.id} with rarity ${card.rarity}`
+        );
+      }
+    }
+  });
+
+  test("tightest cap (uncommon) still covers the 8-player max of 2 traitors", () => {
+    assert.ok(
+      getTraitorPool("uncommon").length >= 2,
+      "Uncommon-only pool cannot seat 2 traitors"
+    );
+  });
+
+  test("the four 'special' traitors are exactly the table-warping ability cards", () => {
+    const specialIds = allTraitors
+      .filter((c) => c.rarity === "special")
+      .map((c) => c.id)
+      .sort();
+    assert.deepStrictEqual(specialIds, [
+      "traitor_07", // The Metamorph
+      "traitor_09", // The Puppet Master
+      "traitor_12", // The Treacherous Masochist
+      "traitor_13", // The Wearer of Masks
+    ]);
+  });
+
+  test("simulation: 500 8-player assignments per cap never exceed the cap", () => {
+    for (const cap of ["uncommon", "rare", "mythic", "special"]) {
+      for (let trial = 0; trial < 500; trial++) {
+        const dist = getRoleDistribution(8);
+        const roles = [];
+        for (let i = 0; i < dist.leaders; i++) roles.push("leader");
+        for (let i = 0; i < dist.guardians; i++) roles.push("guardian");
+        for (let i = 0; i < dist.assassins; i++) roles.push("assassin");
+        for (let i = 0; i < dist.traitors; i++) roles.push("traitor");
+
+        const shuffledRoles = shuffle(roles);
+        const usedCardIds = new Set();
+
+        for (let i = 0; i < 8; i++) {
+          const role = shuffledRoles[i];
+          const rolePool =
+            role === "traitor" ? getTraitorPool(cap) : getCardsForRole(role);
+          const available = rolePool.filter((c) => !usedCardIds.has(c.id));
+          assert.ok(
+            available.length > 0,
+            `Cap '${cap}', trial ${trial}: ran out of ${role} cards`
+          );
+          const card =
+            available[Math.floor(Math.random() * available.length)];
+          if (role === "traitor") {
+            assert.ok(
+              RARITY_ORDER[card.rarity] <= RARITY_ORDER[cap],
+              `Cap '${cap}': assigned traitor ${card.id} with rarity ${card.rarity}`
+            );
+          }
+          usedCardIds.add(card.id);
+        }
+      }
+    }
+  });
+
+  test("updateGameSettings validation: known tiers accepted, junk rejected", () => {
+    for (const good of ["uncommon", "rare", "mythic", "special"]) {
+      assert.ok(isValidRarity(good), `${good} should be accepted`);
+    }
+    for (const bad of ["common", "SPECIAL", "", "constructor", "__proto__", 3, null, {}, []]) {
+      assert.ok(!isValidRarity(bad), `${JSON.stringify(bad)} should be rejected`);
     }
   });
 });


### PR DESCRIPTION
## Summary

Hosts can now cap which traitor identities appear in the random pool when starting a game. Tiers escalate **uncommon < rare < mythic < special** — "special" being the four table-warping traitors (Metamorph, Puppet Master, Treacherous Masochist, Wearer of Masks). The default (Special) keeps today's behavior.

- **Cloud Functions**: `startGame` filters the traitor pool by `game.max_traitor_rarity`; `updateGameSettings` accepts a validated `maxTraitorRarity`. An absent field means no cap, so the change is fully backward compatible for production clients (functions are shared between staging and production).
- **Web**: rarity selector on the create-game screen and a host-only "Max Traitor Rarity" row in the lobby settings card, shown only for treachery modes.
- **Native apps intentionally untouched** — no `Treachery-iOS/**` or `TreacheryAndroid/**` paths, so merging deploys only staging web + functions (no TestFlight/Play runs). Native UI follows after staging validation.

## Test plan

- `functions`: new "Traitor Rarity Cap" unit suite — pool sizes per cap (4/7/9/13), 500-trial 8-player assignment simulation per cap, validation guard incl. prototype-chain keys. 109/109 passing locally.
- New Playwright spec `e2e/traitor-rarity.spec.ts`: host caps rarity at Uncommon via the lobby chip (real `updateGameSettings` round-trip asserted on the game doc), starts a real 4-player game through the Start button, asserts the assigned traitor is one of the four uncommon traitors. Full E2E suite green locally (one pre-existing win-matrix setup flake passed on isolated rerun).
- `npm run typecheck`, both eslint configs, and `build:web` clean locally.

## Staging rollout

Merging to `main` auto-triggers the **Deploy Staging** workflow (staging hosting site + functions + rules) for bug testing before a production release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)