### PR TITLE
Run the functions unit suite in CI and de-flake guest joins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           cache-dependency-path: functions/package-lock.json
       - run: npm ci
       - run: npm run lint
+      # The unit suite was previously not run in CI at all — it gated nothing.
+      - run: npm test
 
   # ── Playwright E2E ───────────────────────────────────
   e2e:

--- a/Treachery/e2e/helpers.ts
+++ b/Treachery/e2e/helpers.ts
@@ -83,7 +83,12 @@ export async function guestJoinGame(page: Page, code: string) {
   await expect(page).toHaveURL(/\/join-game/);
   await page.getByLabel('Game code').fill(code);
   await page.getByRole('button', { name: 'Join game' }).click();
-  await expect(page).toHaveURL(/\/lobby\//);
+  // Specs join guests concurrently (Promise.all), and every joinGame call runs
+  // a transaction against the same game doc, so they serialize and retry under
+  // contention — an 8-player join has been measured at ~9.5s in the emulator,
+  // right at the 10s default. Give it the same headroom signInAsGuest uses
+  // rather than letting a slow-but-successful join read as a failure.
+  await expect(page).toHaveURL(/\/lobby\//, { timeout: 20_000 });
 }
 
 function parseGameIdFromUrl(url: string): string {


### PR DESCRIPTION
**PR 1 of 4** in a stacked series adding a test harness. Merge in order: this → rules → functions integration → simulation.

Two fixes to *existing* test infrastructure. No new tests, no production changes.

### The unit suite never ran in CI
The Cloud Functions job ran only `eslint`, so `functions/test/game-logic.test.js` — 109 tests — gated nothing. A regression in it could merge unnoticed. Verified passing (109/109) before adding it, so this does not turn CI red.

### Guest joins were intermittently flaky
`guestJoinGame` asserted the lobby URL with Playwright's 10s default. Specs join guests concurrently via `Promise.all`, and each `joinGame` transacts against the same game doc, so the calls serialize and retry under contention — an 8-player join measures **~9.5s** in the emulator. The join *succeeds*; the assertion just gives up first.

This surfaced as intermittent failures in `win-matrix` and `traitor-rarity`. Emulator logs show no errors and no contention aborts — purely latency. CI's `retries: 1` has been masking it, so the suite has been flaky-but-green rather than reliably green.

Raised to the 20s `signInAsGuest` already uses. Deliberately **not** a retry loop, which would hide a genuine join failure if one ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)