### PR TITLE
Add Cloud Functions integration tests against the real callables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,38 @@ jobs:
       # The unit suite was previously not run in CI at all — it gated nothing.
       - run: npm test
 
+  # ── Cloud Functions integration ──────────────────────
+  # Drives the REAL exported callables in functions/index.js against the
+  # emulator with genuinely authenticated users. The unit suite above only
+  # exercises re-implementations of the logic copied into the test file,
+  # so it cannot catch a bug in the shipped functions themselves.
+  functions-integration:
+    name: Cloud Functions (integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install firebase-tools
+        run: npm install -g firebase-tools@^15
+
+      - run: npm ci
+      - run: npm run test:integration
+
   # ── Firestore Security Rules ─────────────────────────
   # Tests firestore.rules directly against the emulator. This is the only
   # layer that can reach rules bugs: the Playwright suite drives the UI,

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,8 @@
         "firebase-functions": "^7.1.1"
       },
       "devDependencies": {
-        "eslint": "^8.57.0"
+        "eslint": "^8.57.0",
+        "firebase": "^12.16.0"
       },
       "engines": {
         "node": "22"
@@ -136,48 +137,267 @@
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
     },
-    "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/component": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.1.tgz",
-      "integrity": "sha512-mFzsm7CLHR60o08S23iLUY8m/i6kLpOK87wdEFPLhdlCahaxKmWOwSVGiWoENYSmFJJoDhrR3gKSCxz7ENdIww==",
+    "node_modules/@firebase/ai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.14.0",
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@firebase/database": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.1.tgz",
-      "integrity": "sha512-LwIXe8+mVHY5LBPulWECOOIEXDiatyECp/BOlu0gOhe+WOcKjWHROaCbLlkFTgHMY7RHr5MOxkLP/tltWAH3dA==",
+    "node_modules/@firebase/app-check": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.1",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.14.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.15.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -186,16 +406,16 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.1.tgz",
-      "integrity": "sha512-heAEVZ9Z8c8PnBUcmGh91JHX0cXcVa1yESW/xkLuwaX7idRFyLiN8sl73KXpR8ZArGoPXVQDanBnk6SQiekRCQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.1",
-        "@firebase/database": "1.1.1",
-        "@firebase/database-types": "1.0.17",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.14.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -203,19 +423,178 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.17.tgz",
-      "integrity": "sha512-4eWaM5fW3qEIHjGzfi3cf0Jpqi1xQsAdT6rSDE1RZPrWu8oGjgrq6ybMjobtyHQFgwGCykBm4YM89qDzc+uG/w==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.14.0"
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^0.4.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
-      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -224,10 +603,185 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
     "node_modules/@firebase/util": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.14.0.tgz",
-      "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -236,6 +790,13 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
@@ -405,8 +966,8 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1200,8 +1761,8 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -1506,8 +2067,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1961,6 +2522,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.1",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.15",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-compat": "0.2.27",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
     "node_modules/firebase-admin": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
@@ -2275,8 +2873,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2735,6 +3333,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3064,8 +3669,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -3650,6 +4255,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/re2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3669,8 +4281,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4325,6 +4937,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -4395,8 +5014,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4438,8 +5057,8 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -4454,8 +5073,8 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4473,8 +5092,8 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,14 +9,15 @@
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions",
     "lint": "eslint . --ext .js --max-warnings 0",
-    "test": "node test/game-logic.test.js"
+    "test": "node test/game-logic.test.js",
+    "test:integration": "bash test/integration/callables/run.sh"
   },
   "dependencies": {
     "firebase-admin": "^13.7.0",
     "firebase-functions": "^7.1.1"
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "firebase": "^12.16.0"
   }
 }
-

--- a/functions/test/integration/callables/adjust-life.test.js
+++ b/functions/test/integration/callables/adjust-life.test.js
@@ -1,0 +1,326 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.adjustLife (functions/index.js) and, through it, the
+ * win-condition engine that runs when a player is eliminated.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+/** leader / assassin / assassin / traitor — the documented 4-player layout. */
+const SEATS_4P = [
+  { role: 'leader', card: 'leader_01' },
+  { role: 'assassin', card: 'assassin_01' },
+  { role: 'assassin', card: 'assassin_02' },
+  { role: 'traitor', card: 'traitor_01' },
+];
+
+/** leader / guardian / assassin / assassin / traitor. */
+const SEATS_5P = [
+  { role: 'leader', card: 'leader_01' },
+  { role: 'guardian', card: 'guardian_01' },
+  { role: 'assassin', card: 'assassin_01' },
+  { role: 'assassin', card: 'assassin_02' },
+  { role: 'traitor', card: 'traitor_01' },
+];
+
+async function startedTreacheryGame(seats) {
+  const users = await h.getUsers(seats.length);
+  return h.seedStartedGame({ users, seats, startingLife: 40 });
+}
+
+describe('adjustLife — arithmetic & elimination', () => {
+  it('subtracts life without eliminating while life remains', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const res = await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p1',
+      amount: -13,
+    });
+    assert.equal(res.newLife, 27);
+    assert.equal(res.eliminated, false);
+    assert.equal(res.winner, null);
+
+    const p = await h.getPlayer(game.gameId, 'p1');
+    assert.equal(p.life_total, 27);
+    assert.equal(p.is_eliminated, false);
+    assert.equal(p.is_unveiled, false);
+  });
+
+  it('adds life too', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const res = await game.users[0].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p1',
+      amount: 5,
+    });
+    assert.equal(res.newLife, 45);
+    assert.equal(res.eliminated, false);
+  });
+
+  it('eliminates and unveils a player who lands on exactly 0', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const res = await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p1',
+      amount: -40,
+    });
+    assert.equal(res.newLife, 0);
+    assert.equal(res.eliminated, true);
+
+    const p = await h.getPlayer(game.gameId, 'p1');
+    assert.equal(p.life_total, 0);
+    assert.equal(p.is_eliminated, true);
+    assert.equal(p.is_unveiled, true, 'elimination reveals the identity');
+  });
+
+  it('clamps overkill damage to 0 rather than storing a negative life total', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const res = await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p1',
+      amount: -1000,
+    });
+    assert.equal(res.newLife, 0);
+    assert.equal(res.eliminated, true);
+
+    const p = await h.getPlayer(game.gameId, 'p1');
+    assert.equal(p.life_total, 0, 'life must never go below zero');
+  });
+});
+
+describe('adjustLife — authorisation & preconditions', () => {
+  it('rejects a caller who is not in the game', async () => {
+    const users = await h.getUsers(5);
+    const game = await h.seedStartedGame({
+      users: users.slice(0, 4),
+      seats: SEATS_4P,
+    });
+    const outsider = users[4];
+    await h.expectHttpsError(
+      outsider.call('adjustLife', { gameId: game.gameId, playerId: 'p1', amount: -5 }),
+      'permission-denied'
+    );
+    const p = await h.getPlayer(game.gameId, 'p1');
+    assert.equal(p.life_total, 40, 'a rejected adjustment must not persist');
+  });
+
+  it('rejects editing an already-eliminated player', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p1',
+      amount: -40,
+    });
+    await h.expectHttpsError(
+      game.users[1].call('adjustLife', { gameId: game.gameId, playerId: 'p1', amount: 5 }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects adjustments while the game is still waiting', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      game.host.call('adjustLife', { gameId: game.gameId, playerId: 'p0', amount: -1 }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a non-integer amount', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await h.expectHttpsError(
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId: 'p1', amount: 1.5 }),
+      'invalid-argument'
+    );
+    await h.expectHttpsError(
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId: 'p1', amount: '-5' }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a missing amount', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await h.expectHttpsError(
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId: 'p1' }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects an unknown player id', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await h.expectHttpsError(
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId: 'nope', amount: -1 }),
+      'not-found'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('adjustLife', {
+        gameId: game.gameId,
+        playerId: 'p1',
+        amount: -1,
+      }),
+      'unauthenticated'
+    );
+  });
+});
+
+describe('adjustLife — treachery win conditions', () => {
+  it('assassins win the moment the Leader is eliminated', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const res = await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p0',
+      amount: -40,
+    });
+    assert.equal(res.winner, 'assassin');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'finished');
+    assert.equal(g.winning_team, 'assassin');
+  });
+
+  it('the Leader wins once every assassin and traitor is out', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const kill = (playerId) =>
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId, amount: -40 });
+
+    assert.equal((await kill('p3')).winner, null, 'traitor out — game continues');
+    assert.equal((await kill('p1')).winner, null, 'one assassin left — game continues');
+    assert.equal((await kill('p2')).winner, 'leader');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'finished');
+    assert.equal(g.winning_team, 'leader');
+  });
+
+  it('a surviving Guardian counts towards the Leader win', async () => {
+    const game = await startedTreacheryGame(SEATS_5P);
+    const kill = (playerId) =>
+      game.users[0].call('adjustLife', { gameId: game.gameId, playerId, amount: -40 });
+
+    assert.equal((await kill('p4')).winner, null, 'traitor out');
+    assert.equal((await kill('p2')).winner, null, 'one assassin left');
+    assert.equal((await kill('p3')).winner, 'leader');
+
+    const players = await h.getPlayers(game.gameId);
+    const guardian = players.find((p) => p.role === 'guardian');
+    assert.equal(guardian.is_eliminated, false, 'the guardian survived');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.winning_team, 'leader');
+  });
+
+  it('the traitor wins by being the last player standing', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    const kill = (playerId) =>
+      game.users[3].call('adjustLife', { gameId: game.gameId, playerId, amount: -40 });
+
+    assert.equal((await kill('p1')).winner, null, 'first assassin out');
+    assert.equal((await kill('p2')).winner, null, 'second assassin out — leader still alive');
+    assert.equal((await kill('p0')).winner, 'traitor', 'leader out, traitor alone');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'finished');
+    assert.equal(g.winning_team, 'traitor');
+  });
+
+  it('rejects further adjustments after the game has finished', async () => {
+    const game = await startedTreacheryGame(SEATS_4P);
+    await game.users[1].call('adjustLife', {
+      gameId: game.gameId,
+      playerId: 'p0',
+      amount: -40,
+    });
+    await h.expectHttpsError(
+      game.users[1].call('adjustLife', { gameId: game.gameId, playerId: 'p3', amount: -5 }),
+      'failed-precondition'
+    );
+  });
+});
+
+describe('adjustLife — non-treachery modes must not auto-finish', () => {
+  // SKIP: currently broken — see finding #B. Un-skip when functions/index.js is fixed.
+  //
+  // checkWinConditions() (index.js ~143) has no game-mode guard. In
+  // "none"/"planechase" games every player's `role` is null, so the
+  // "!leaderAlive && !assassinAlive && !traitorAlive" branch fires on the very
+  // first elimination and hands the game to the (non-existent) assassins.
+  // A Life Tracker game therefore ends as soon as one player hits 0.
+  for (const mode of ['none', 'planechase']) {
+    it(
+      `a "${mode}" game keeps running when a player drops to 0 life`,
+      { skip: 'currently broken — see finding #B' },
+      async () => {
+        const users = await h.getUsers(4);
+        const game = await h.seedGame({ users, gameMode: mode, startingLife: 40 });
+        await game.host.call('startGame', { gameId: game.gameId });
+
+        const res = await game.users[1].call('adjustLife', {
+          gameId: game.gameId,
+          playerId: 'p1',
+          amount: -40,
+        });
+
+        assert.equal(res.eliminated, true, 'the player is still eliminated');
+        assert.equal(
+          res.winner,
+          null,
+          `a "${mode}" game has no automatic win condition`
+        );
+
+        const g = await h.getGame(game.gameId);
+        assert.equal(
+          g.state,
+          'in_progress',
+          `a "${mode}" game must not finish itself after one elimination`
+        );
+        assert.equal(
+          g.winning_team,
+          undefined,
+          `a "${mode}" game must never set winning_team`
+        );
+      }
+    );
+  }
+
+  // SKIP: currently broken — see finding #B. Un-skip when functions/index.js is fixed.
+  //
+  // The same bug means the host can never legitimately call endGame: the game
+  // has already flipped to "finished" behind their back.
+  it(
+    'the host can still end a Life Tracker game explicitly after an elimination',
+    { skip: 'currently broken — see finding #B' },
+    async () => {
+      const users = await h.getUsers(4);
+      const game = await h.seedGame({ users, gameMode: 'none', startingLife: 40 });
+      await game.host.call('startGame', { gameId: game.gameId });
+
+      await game.users[1].call('adjustLife', {
+        gameId: game.gameId,
+        playerId: 'p1',
+        amount: -40,
+      });
+
+      const res = await game.host.call('endGame', {
+        gameId: game.gameId,
+        winnerUserIds: [users[0].uid],
+      });
+      assert.deepEqual(res, { action: 'ended' });
+
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.state, 'finished');
+      assert.deepEqual(g.winner_user_ids, [users[0].uid]);
+      assert.equal(g.winning_team, undefined);
+    }
+  );
+});

--- a/functions/test/integration/callables/firebase.emulators.json
+++ b/functions/test/integration/callables/firebase.emulators.json
@@ -1,0 +1,33 @@
+{
+  "_comment": [
+    "Emulator config used ONLY by `npm run test:integration` (functions/).",
+    "Deliberately separate from the repo-root firebase.json so the integration",
+    "suite can run on its own ports without colliding with the Playwright E2E",
+    "suite (auth 9099 / firestore 8087 / functions 5001). The auxiliary",
+    "emulators (hub / logging / eventarc / tasks / firestore websocket) are",
+    "pinned off their defaults for the same reason.",
+    "Paths are resolved relative to THIS file's directory, which firebase-tools",
+    "treats as the project root when --config points here.",
+    "No firestore.rules entry: the suite only touches Firestore through the",
+    "Admin SDK (which bypasses rules) and through the callables themselves."
+  ],
+  "firestore": {},
+  "functions": [
+    {
+      "source": "../../..",
+      "codebase": "default",
+      "ignore": ["node_modules", ".git", "test"]
+    }
+  ],
+  "emulators": {
+    "auth": { "port": 9299 },
+    "firestore": { "port": 8288, "websocketPort": 9151 },
+    "functions": { "port": 5201 },
+    "eventarc": { "port": 9298 },
+    "tasks": { "port": 9297 },
+    "hub": { "port": 4460 },
+    "logging": { "port": 4560 },
+    "ui": { "enabled": false },
+    "singleProjectMode": true
+  }
+}

--- a/functions/test/integration/callables/helpers.js
+++ b/functions/test/integration/callables/helpers.js
@@ -1,0 +1,327 @@
+'use strict';
+
+/**
+ * Shared harness for the Cloud Functions INTEGRATION suite.
+ *
+ * Unlike test/game-logic.test.js (which re-implements the logic it checks),
+ * everything here drives the REAL callables exported from functions/index.js
+ * as they run inside the Firebase emulator.
+ *
+ * Strategy: the Firebase **client** SDK (firebase/app + firebase/auth +
+ * firebase/functions) pointed at the emulators. Every test user is a real
+ * anonymous Auth account, so `request.auth.uid` inside the callable is
+ * populated exactly the way it is in production and every auth/permission
+ * branch is genuinely exercised. `firebase-admin` (which bypasses security
+ * rules) is used only to seed fixtures and to read back resulting state.
+ *
+ * Ports are owned by this suite alone — see firebase.emulators.json.
+ */
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+
+const { initializeApp: initAdminApp } = require('firebase-admin/app');
+const { getFirestore, FieldValue } = require('firebase-admin/firestore');
+
+const { initializeApp: initClientApp, deleteApp } = require('firebase/app');
+const {
+  getAuth,
+  connectAuthEmulator,
+  signInAnonymously,
+} = require('firebase/auth');
+const {
+  getFunctions,
+  connectFunctionsEmulator,
+  httpsCallable,
+} = require('firebase/functions');
+
+// ── Emulator wiring ─────────────────────────────────────────────
+// `firebase emulators:exec` exports FIRESTORE_EMULATOR_HOST and
+// FIREBASE_AUTH_EMULATOR_HOST; the functions port has no standard env var,
+// so it is read from INTEGRATION_FUNCTIONS_PORT with a matching default.
+
+const PROJECT_ID = process.env.GCLOUD_PROJECT || 'demo-test';
+const AUTH_EMULATOR_URL = `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST || '127.0.0.1:9299'}`;
+const FUNCTIONS_PORT = Number(process.env.INTEGRATION_FUNCTIONS_PORT || 5201);
+const FUNCTIONS_HOST = process.env.INTEGRATION_FUNCTIONS_HOST || '127.0.0.1';
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8288';
+}
+
+initAdminApp({ projectId: PROJECT_ID });
+const db = getFirestore();
+
+// ── Card data (read-only reference used for expectations) ───────
+
+const CARDS = require('../../../identityCards.json');
+const cardById = (id) => CARDS.find((c) => c.id === id);
+const cardsForRole = (role) => CARDS.filter((c) => c.role === role);
+
+/**
+ * The documented role distribution. This is the SPEC the suite asserts
+ * against — deliberately a literal table, not a call into index.js.
+ */
+const EXPECTED_DISTRIBUTION = {
+  4: { leader: 1, guardian: 0, assassin: 2, traitor: 1 },
+  5: { leader: 1, guardian: 1, assassin: 2, traitor: 1 },
+  6: { leader: 1, guardian: 1, assassin: 3, traitor: 1 },
+  7: { leader: 1, guardian: 2, assassin: 3, traitor: 1 },
+  8: { leader: 1, guardian: 2, assassin: 3, traitor: 2 },
+};
+
+/** The four traitors whose rarity is `uncommon`. */
+const UNCOMMON_TRAITORS = ['traitor_01', 'traitor_04', 'traitor_05', 'traitor_08'];
+
+// ── Client-SDK test users ───────────────────────────────────────
+
+let appCounter = 0;
+const clientApps = [];
+const userPool = [];
+
+function newClientApp() {
+  const name = `it-client-${process.pid}-${appCounter++}`;
+  const app = initClientApp(
+    { projectId: PROJECT_ID, apiKey: 'demo-key', appId: 'demo-app' },
+    name
+  );
+  const auth = getAuth(app);
+  connectAuthEmulator(auth, AUTH_EMULATOR_URL, { disableWarnings: true });
+  const fns = getFunctions(app);
+  connectFunctionsEmulator(fns, FUNCTIONS_HOST, FUNCTIONS_PORT);
+  clientApps.push(app);
+  return { app, auth, fns };
+}
+
+function makeCaller(fns) {
+  return async (name, data) => {
+    const res = await httpsCallable(fns, name)(data);
+    return res.data;
+  };
+}
+
+/**
+ * A signed-in test user. `call(name, data)` invokes a callable with this
+ * user's ID token attached, which is what populates request.auth.uid.
+ */
+async function createUser(label) {
+  const { app, auth, fns } = newClientApp();
+  const cred = await signInAnonymously(auth);
+  const uid = cred.user.uid;
+  const displayName = label || `Player ${userPool.length + 1}`;
+  await db.doc(`users/${uid}`).set({
+    display_name: displayName,
+    elo: 1500,
+    created_at: FieldValue.serverTimestamp(),
+  });
+  return { uid, displayName, app, auth, call: makeCaller(fns) };
+}
+
+/** Returns (creating on first use) `n` reusable signed-in test users. */
+async function getUsers(n) {
+  while (userPool.length < n) {
+    // eslint-disable-next-line no-await-in-loop
+    userPool.push(await createUser(`Player ${userPool.length + 1}`));
+  }
+  return userPool.slice(0, n);
+}
+
+let anonCaller = null;
+/** A caller with NO signed-in user — exercises the `unauthenticated` branch. */
+function unauthenticatedCaller() {
+  if (!anonCaller) {
+    const { fns } = newClientApp();
+    anonCaller = makeCaller(fns);
+  }
+  return anonCaller;
+}
+
+// ── Fixtures ────────────────────────────────────────────────────
+
+/** Wide enough that parallel test files never collide on a lobby code. */
+function uniqueCode() {
+  return crypto.randomBytes(6).toString('hex').toUpperCase();
+}
+
+/**
+ * Seeds a lobby straight into Firestore with firebase-admin (bypasses rules,
+ * which is what the app's own Cloud Functions do anyway).
+ *
+ * Player doc ids are deterministic: p0, p1, ... in seat order.
+ */
+async function seedGame({
+  users,
+  host,
+  state = 'waiting',
+  gameMode = 'treachery',
+  startingLife = 40,
+  maxPlayers = 8,
+  maxTraitorRarity,
+  planechase,
+  playerOverrides = {},
+  gameFields = {},
+} = {}) {
+  assert.ok(users && users.length > 0, 'seedGame requires at least one user');
+  const hostUser = host || users[0];
+  const code = uniqueCode();
+  const gameRef = db.collection('games').doc();
+
+  const gameDoc = {
+    code,
+    host_id: hostUser.uid,
+    player_ids: users.map((u) => u.uid),
+    state,
+    game_mode: gameMode,
+    starting_life: startingLife,
+    max_players: maxPlayers,
+    created_at: FieldValue.serverTimestamp(),
+    last_activity_at: FieldValue.serverTimestamp(),
+    ...gameFields,
+  };
+  if (maxTraitorRarity !== undefined) gameDoc.max_traitor_rarity = maxTraitorRarity;
+  if (planechase !== undefined) gameDoc.planechase = planechase;
+
+  await gameRef.set(gameDoc);
+
+  const players = [];
+  const batch = db.batch();
+  users.forEach((u, i) => {
+    const id = `p${i}`;
+    const ref = gameRef.collection('players').doc(id);
+    batch.set(ref, {
+      user_id: u.uid,
+      display_name: u.displayName,
+      order_id: i,
+      role: null,
+      identity_card_id: null,
+      life_total: startingLife,
+      is_eliminated: false,
+      is_unveiled: false,
+      joined_at: FieldValue.serverTimestamp(),
+      ...(playerOverrides[i] || {}),
+    });
+    players.push({ id, uid: u.uid, user: u, seat: i });
+  });
+  await batch.commit();
+
+  return { gameId: gameRef.id, code, ref: gameRef, host: hostUser, users, players };
+}
+
+/**
+ * Seeds a lobby and then starts it for real via the `startGame` callable,
+ * using the emulator-only testSeed hook for deterministic role/card layout.
+ *
+ * `seats` is aligned with `users`: [{ role, card }, ...]
+ */
+async function seedStartedGame({ users, seats, ...rest }) {
+  const game = await seedGame({ users, ...rest });
+  const assignments = {};
+  users.forEach((u, i) => {
+    assignments[u.uid] = { role: seats[i].role, identityCardId: seats[i].card };
+  });
+  await game.host.call('startGame', { gameId: game.gameId, testSeed: { assignments } });
+  return game;
+}
+
+// ── Reads / mutations for assertions & mid-test state setup ─────
+
+async function getGame(gameId) {
+  const snap = await db.doc(`games/${gameId}`).get();
+  return snap.exists ? { id: snap.id, ...snap.data() } : null;
+}
+
+async function getPlayers(gameId) {
+  const snap = await db.collection(`games/${gameId}/players`).orderBy('order_id').get();
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+async function getPlayer(gameId, playerDocId) {
+  const snap = await db.doc(`games/${gameId}/players/${playerDocId}`).get();
+  return snap.exists ? { id: snap.id, ...snap.data() } : null;
+}
+
+/** Directly edits a player doc to set up a mid-game state. */
+function patchPlayer(gameId, playerDocId, patch) {
+  return db.doc(`games/${gameId}/players/${playerDocId}`).update(patch);
+}
+
+/** Directly edits the game doc to set up a mid-game state. */
+function patchGame(gameId, patch) {
+  return db.doc(`games/${gameId}`).update(patch);
+}
+
+// ── Assertions ──────────────────────────────────────────────────
+
+/**
+ * Awaits `promise`, asserting it rejects with the given HttpsError code.
+ * The client SDK prefixes codes with "functions/", which is normalised away.
+ */
+async function expectHttpsError(promise, expectedCode) {
+  let error = null;
+  let resolved;
+  let didResolve = false;
+  try {
+    resolved = await promise;
+    didResolve = true;
+  } catch (e) {
+    error = e;
+  }
+  if (didResolve) {
+    assert.fail(
+      `Expected HttpsError "${expectedCode}" but the call succeeded with ${JSON.stringify(resolved)}`
+    );
+  }
+  const code = String(error.code || '').replace(/^functions\//, '');
+  assert.equal(
+    code,
+    expectedCode,
+    `Expected HttpsError "${expectedCode}" but got "${code}": ${error.message}`
+  );
+  return error;
+}
+
+/** Counts roles across player docs. */
+function roleCounts(players) {
+  const counts = { leader: 0, guardian: 0, assassin: 0, traitor: 0 };
+  for (const p of players) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(counts, p.role),
+      `Unexpected role assigned: ${JSON.stringify(p.role)}`
+    );
+    counts[p.role] += 1;
+  }
+  return counts;
+}
+
+// ── Teardown ────────────────────────────────────────────────────
+
+async function shutdown() {
+  await Promise.all(clientApps.map((a) => deleteApp(a).catch(() => {})));
+  clientApps.length = 0;
+  userPool.length = 0;
+  anonCaller = null;
+  await db.terminate().catch(() => {});
+}
+
+module.exports = {
+  db,
+  FieldValue,
+  CARDS,
+  cardById,
+  cardsForRole,
+  EXPECTED_DISTRIBUTION,
+  UNCOMMON_TRAITORS,
+  getUsers,
+  createUser,
+  unauthenticatedCaller,
+  seedGame,
+  seedStartedGame,
+  getGame,
+  getPlayers,
+  getPlayer,
+  patchPlayer,
+  patchGame,
+  expectHttpsError,
+  roleCounts,
+  shutdown,
+};

--- a/functions/test/integration/callables/join-leave.test.js
+++ b/functions/test/integration/callables/join-leave.test.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.joinGame and exports.leaveGame (functions/index.js)
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+describe('joinGame', () => {
+  it('adds the caller to a waiting lobby and is case-insensitive on the code', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users: [users[0]], maxPlayers: 8, startingLife: 30 });
+
+    const res = await users[1].call('joinGame', { gameCode: game.code.toLowerCase() });
+    assert.equal(res.action, 'joined');
+    assert.equal(res.gameId, game.gameId);
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 2);
+    const joined = players.find((p) => p.user_id === users[1].uid);
+    assert.ok(joined, 'a player doc must be created for the joiner');
+    assert.equal(joined.order_id, 1, 'order_id follows the current player count');
+    assert.equal(joined.display_name, users[1].displayName);
+    assert.equal(joined.life_total, 30, "life_total seeds from the game's starting life");
+    assert.equal(joined.role, null);
+    assert.equal(joined.is_eliminated, false);
+
+    const g = await h.getGame(game.gameId);
+    assert.ok(g.player_ids.includes(users[1].uid), 'player_ids must include the joiner');
+  });
+
+  it('is idempotent for a player who is already in the game', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users });
+
+    const res = await users[1].call('joinGame', { gameCode: game.code });
+    assert.equal(res.action, 'already_joined');
+    assert.equal(res.gameId, game.gameId);
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 2, 'no duplicate player doc');
+  });
+
+  it('enforces the lobby capacity', async () => {
+    const users = await h.getUsers(3);
+    const game = await h.seedGame({ users: users.slice(0, 2), maxPlayers: 2 });
+
+    await h.expectHttpsError(
+      users[2].call('joinGame', { gameCode: game.code }),
+      'failed-precondition'
+    );
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 2, 'a rejected join must not create a player doc');
+    const g = await h.getGame(game.gameId);
+    assert.ok(!g.player_ids.includes(users[2].uid));
+  });
+
+  it('rejects joining a game that is already in progress', async () => {
+    const users = await h.getUsers(5);
+    const game = await h.seedGame({ users: users.slice(0, 4) });
+    await game.host.call('startGame', { gameId: game.gameId });
+
+    await h.expectHttpsError(
+      users[4].call('joinGame', { gameCode: game.code }),
+      'failed-precondition'
+    );
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 4);
+  });
+
+  it('rejects an unknown game code', async () => {
+    const [user] = await h.getUsers(1);
+    await h.expectHttpsError(
+      user.call('joinGame', { gameCode: 'ZZZZZZ' }),
+      'not-found'
+    );
+  });
+
+  it('rejects a missing game code', async () => {
+    const [user] = await h.getUsers(1);
+    await h.expectHttpsError(user.call('joinGame', {}), 'invalid-argument');
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const users = await h.getUsers(1);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('joinGame', { gameCode: game.code }),
+      'unauthenticated'
+    );
+  });
+});
+
+describe('leaveGame', () => {
+  it('promotes the next player to host when the host leaves a non-empty lobby', async () => {
+    const users = await h.getUsers(3);
+    const game = await h.seedGame({ users });
+
+    const res = await game.host.call('leaveGame', { gameId: game.gameId });
+    assert.equal(res.action, 'promoted');
+    assert.equal(res.newHostId, users[1].uid, 'lowest remaining order_id becomes host');
+
+    const g = await h.getGame(game.gameId);
+    assert.ok(g, 'the game must survive the host leaving');
+    assert.equal(g.host_id, users[1].uid);
+    assert.deepEqual(g.player_ids, [users[1].uid, users[2].uid]);
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 2);
+    assert.ok(!players.some((p) => p.user_id === users[0].uid));
+  });
+
+  it('deletes the game when the last player leaves', async () => {
+    const users = await h.getUsers(1);
+    const game = await h.seedGame({ users });
+
+    const res = await game.host.call('leaveGame', { gameId: game.gameId });
+    assert.equal(res.action, 'deleted');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g, null, 'the game doc must be removed');
+  });
+
+  it('removes a non-host without changing the host', async () => {
+    const users = await h.getUsers(3);
+    const game = await h.seedGame({ users });
+
+    const res = await users[1].call('leaveGame', { gameId: game.gameId });
+    assert.equal(res.action, 'left');
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.host_id, users[0].uid);
+    assert.deepEqual(g.player_ids, [users[0].uid, users[2].uid]);
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 2);
+    assert.ok(!players.some((p) => p.user_id === users[1].uid));
+  });
+
+  it('rejects leaving a game that is in progress', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await game.host.call('startGame', { gameId: game.gameId });
+
+    await h.expectHttpsError(
+      users[1].call('leaveGame', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players.length, 4);
+  });
+
+  it('rejects a caller who is not in the game', async () => {
+    const users = await h.getUsers(3);
+    const game = await h.seedGame({ users: users.slice(0, 2) });
+    await h.expectHttpsError(
+      users[2].call('leaveGame', { gameId: game.gameId }),
+      'not-found'
+    );
+  });
+
+  it('rejects an unknown gameId', async () => {
+    const [user] = await h.getUsers(1);
+    await h.expectHttpsError(
+      user.call('leaveGame', { gameId: 'nope' }),
+      'not-found'
+    );
+  });
+
+  // SKIP: currently broken — see finding #G. Un-skip when functions/index.js is fixed.
+  //
+  // leaveGame deletes the player doc but never renumbers the survivors, while
+  // joinGame derives the new seat as `orderId = existingPlayers.length`. So
+  // after anyone but the last player leaves, the next joiner collides with an
+  // existing order_id: seats 0,1,2 minus seat 1 leaves 0,2 (length 2), and the
+  // joiner is also given 2. Two players then share a seat number, which makes
+  // every `orderBy("order_id")` read (startGame, adjustLife, leaveGame's own
+  // host promotion) non-deterministic.
+  it(
+    'keeps order_id unique after a middle player leaves and a new one joins',
+    { skip: 'currently broken — see finding #G' },
+    async () => {
+      const users = await h.getUsers(4);
+      const game = await h.seedGame({ users: users.slice(0, 3), maxPlayers: 8 });
+
+      await users[1].call('leaveGame', { gameId: game.gameId });
+      await users[3].call('joinGame', { gameCode: game.code });
+
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(players.length, 3);
+      const orderIds = players.map((p) => p.order_id);
+      assert.equal(
+        new Set(orderIds).size,
+        orderIds.length,
+        `order_id must stay unique, got ${orderIds.join(', ')}`
+      );
+    }
+  );
+
+  it('rejects an unauthenticated caller', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('leaveGame', { gameId: game.gameId }),
+      'unauthenticated'
+    );
+  });
+});

--- a/functions/test/integration/callables/run.sh
+++ b/functions/test/integration/callables/run.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Boots the Firebase emulators on this suite's own ports and runs the
+# Cloud Functions integration tests against them.
+#
+#   cd functions && npm run test:integration
+#
+# Optional args are forwarded to `node --test`, e.g.
+#   npm run test:integration -- --test-name-pattern "win condition"
+#
+# Ports default to auth 9299 / firestore 8288 / functions 5201 (deliberately
+# clear of the Playwright E2E suite, which uses the repo-root firebase.json).
+# If something else already holds one of them, retarget without editing any
+# committed file:
+#   INTEGRATION_AUTH_PORT=9399 npm run test:integration
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTIONS_DIR="$(cd "$HERE/../../.." && pwd)"
+cd "$FUNCTIONS_DIR"
+
+BASE_CONFIG="test/integration/callables/firebase.emulators.json"
+
+AUTH_PORT="${INTEGRATION_AUTH_PORT:-9299}"
+FIRESTORE_PORT="${INTEGRATION_FIRESTORE_PORT:-8288}"
+FUNCTIONS_PORT="${INTEGRATION_FUNCTIONS_PORT:-5201}"
+export INTEGRATION_FUNCTIONS_PORT="$FUNCTIONS_PORT"
+
+# ── firebase-tools ──────────────────────────────────────────────
+if ! command -v firebase >/dev/null 2>&1; then
+  echo "error: the 'firebase' CLI is not on PATH." >&2
+  echo "       install it with:  npm install -g firebase-tools" >&2
+  exit 1
+fi
+
+# ── Java 21+ (firebase-tools refuses to start the emulators below 21) ──
+java_major() {
+  local out
+  out="$("$1" -version 2>&1 | head -1)" || return 1
+  # matches:  openjdk version "23.0.2" ...   /   java version "1.8.0_401"
+  printf '%s' "$out" | sed -E 's/^[^"]*"([0-9]+).*/\1/'
+}
+
+java_ok() {
+  local bin="$1" major
+  [ -x "$bin" ] || return 1
+  major="$(java_major "$bin" 2>/dev/null || true)"
+  case "$major" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$major" -ge 21 ]
+}
+
+CANDIDATE_HOMES=()
+[ -n "${JAVA_HOME:-}" ] && CANDIDATE_HOMES+=("$JAVA_HOME")
+if [ -x /usr/libexec/java_home ]; then
+  for v in 25 24 23 22 21; do
+    home="$(/usr/libexec/java_home -v "$v" 2>/dev/null || true)"
+    [ -n "$home" ] && CANDIDATE_HOMES+=("$home")
+  done
+fi
+for v in 25 24 23 22 21; do
+  for home in \
+    "/opt/homebrew/opt/openjdk@$v/libexec/openjdk.jdk/Contents/Home" \
+    "/usr/local/opt/openjdk@$v/libexec/openjdk.jdk/Contents/Home" \
+    "/usr/lib/jvm/temurin-$v-jdk" \
+    "/usr/lib/jvm/java-$v-openjdk-amd64"; do
+    [ -d "$home" ] && CANDIDATE_HOMES+=("$home")
+  done
+done
+
+SELECTED_JAVA_HOME=""
+for home in "${CANDIDATE_HOMES[@]:-}"; do
+  if java_ok "$home/bin/java"; then
+    SELECTED_JAVA_HOME="$home"
+    break
+  fi
+done
+
+if [ -n "$SELECTED_JAVA_HOME" ]; then
+  export JAVA_HOME="$SELECTED_JAVA_HOME"
+  export PATH="$JAVA_HOME/bin:$PATH"
+elif ! java_ok "$(command -v java || echo /nonexistent)"; then
+  echo "error: the Firebase emulators need Java 21 or newer." >&2
+  echo "       found: $(command -v java >/dev/null 2>&1 && java -version 2>&1 | head -1 || echo 'no java on PATH')" >&2
+  echo "       fix:   brew install openjdk@23   (or set JAVA_HOME to a 21+ JDK)" >&2
+  exit 1
+fi
+
+# ── Config (regenerated only when ports are overridden) ─────────
+CONFIG="$BASE_CONFIG"
+TMP_CONFIG=""
+if [ "$AUTH_PORT" != "9299" ] || [ "$FIRESTORE_PORT" != "8288" ] || [ "$FUNCTIONS_PORT" != "5201" ]; then
+  # Must live next to the template: firebase-tools resolves functions.source
+  # relative to the directory holding the config file.
+  TMP_CONFIG="test/integration/callables/.emulators.override.json"
+  node -e '
+    const fs = require("fs");
+    const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    cfg.emulators.auth.port = Number(process.argv[3]);
+    cfg.emulators.firestore.port = Number(process.argv[4]);
+    cfg.emulators.functions.port = Number(process.argv[5]);
+    fs.writeFileSync(process.argv[2], JSON.stringify(cfg, null, 2));
+  ' "$BASE_CONFIG" "$TMP_CONFIG" "$AUTH_PORT" "$FIRESTORE_PORT" "$FUNCTIONS_PORT"
+  CONFIG="$TMP_CONFIG"
+fi
+
+# ── Run ─────────────────────────────────────────────────────────
+# The emulator streams a lot of noise to stdout, so the test reporter writes
+# to its own file which is printed once the emulators have shut down.
+RESULTS="$(mktemp "${TMPDIR:-/tmp}/treachery-integration.XXXXXX")"
+cleanup() {
+  rm -f "$RESULTS"
+  [ -n "$TMP_CONFIG" ] && rm -f "$TMP_CONFIG"
+  # Must end truthy: a failing last command in an EXIT trap overrides the
+  # script's own exit status, which would report a green run as a failure.
+  return 0
+}
+trap cleanup EXIT
+
+CMD="node --test --test-concurrency=1 --test-reporter=spec"
+CMD="$CMD --test-reporter-destination=$(printf '%q' "$RESULTS")"
+for arg in "$@"; do CMD="$CMD $(printf '%q' "$arg")"; done
+# Explicit glob rather than the directory, so helpers.js is never mistaken
+# for a test file.
+CMD="$CMD test/integration/callables/*.test.js"
+
+set +e
+firebase emulators:exec \
+  --project=demo-test \
+  --only auth,firestore,functions \
+  --config="$CONFIG" \
+  "$CMD"
+STATUS=$?
+set -e
+
+echo
+echo "════════════════ integration test results ════════════════"
+cat "$RESULTS"
+
+exit "$STATUS"

--- a/functions/test/integration/callables/start-game.test.js
+++ b/functions/test/integration/callables/start-game.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.startGame (functions/index.js)
+ *
+ * Drives the real callable against the emulator: seeds a lobby with
+ * firebase-admin, signs in as the host with the client SDK, invokes
+ * startGame, and asserts on the Firestore state it produced.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+describe('startGame — treachery role & card assignment', () => {
+  for (const count of [4, 5, 6, 7, 8]) {
+    it(`assigns the documented role distribution for ${count} players`, async () => {
+      const users = await h.getUsers(count);
+      const game = await h.seedGame({ users, startingLife: 40 });
+
+      const res = await game.host.call('startGame', { gameId: game.gameId });
+      assert.deepEqual(res, { success: true });
+
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(players.length, count);
+      assert.deepEqual(
+        h.roleCounts(players),
+        h.EXPECTED_DISTRIBUTION[count],
+        `role distribution for ${count} players`
+      );
+
+      const cardIds = players.map((p) => p.identity_card_id);
+      assert.equal(
+        new Set(cardIds).size,
+        count,
+        `identity cards must be unique, got ${cardIds.join(', ')}`
+      );
+
+      for (const p of players) {
+        const card = h.cardById(p.identity_card_id);
+        assert.ok(card, `unknown identity card ${p.identity_card_id}`);
+        assert.equal(card.role, p.role, `card ${card.id} must match assigned role`);
+        assert.equal(
+          p.life_total,
+          40 + (card.life_modifier || 0),
+          `life_total for ${card.id} (life_modifier ${card.life_modifier})`
+        );
+      }
+
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.state, 'in_progress');
+      assert.ok(g.last_activity_at, 'last_activity_at must be stamped');
+    });
+  }
+
+  it('applies the card life_modifier on top of a non-default starting life', async () => {
+    const users = await h.getUsers(4);
+    // leader_10 (The Old Ruler) is the only card with a life_modifier (+20).
+    const game = await h.seedStartedGame({
+      users,
+      startingLife: 25,
+      seats: [
+        { role: 'leader', card: 'leader_10' },
+        { role: 'assassin', card: 'assassin_01' },
+        { role: 'assassin', card: 'assassin_02' },
+        { role: 'traitor', card: 'traitor_01' },
+      ],
+    });
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players[0].life_total, 45, 'leader_10 = 25 starting life + 20 modifier');
+    assert.equal(players[1].life_total, 25);
+    assert.equal(players[2].life_total, 25);
+    assert.equal(players[3].life_total, 25);
+  });
+});
+
+describe('startGame — authorisation & preconditions', () => {
+  it('rejects a non-host with permission-denied', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      users[1].call('startGame', { gameId: game.gameId }),
+      'permission-denied'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'waiting', 'a rejected start must not change game state');
+  });
+
+  it('rejects starting a game that is already in progress', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await game.host.call('startGame', { gameId: game.gameId });
+    await h.expectHttpsError(
+      game.host.call('startGame', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('startGame', { gameId: game.gameId }),
+      'unauthenticated'
+    );
+  });
+
+  it('rejects a missing gameId', async () => {
+    const [host] = await h.getUsers(1);
+    await h.expectHttpsError(host.call('startGame', {}), 'invalid-argument');
+  });
+
+  it('rejects an unknown gameId', async () => {
+    const [host] = await h.getUsers(1);
+    await h.expectHttpsError(
+      host.call('startGame', { gameId: 'does-not-exist' }),
+      'not-found'
+    );
+  });
+});
+
+describe('startGame — testSeed validation (emulator-only hook)', () => {
+  it('rejects a seed whose role counts do not match the distribution', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    const assignments = {};
+    // 2 leaders / 1 assassin / 1 traitor — not the 4-player distribution.
+    const bad = [
+      { role: 'leader', card: 'leader_01' },
+      { role: 'leader', card: 'leader_02' },
+      { role: 'assassin', card: 'assassin_01' },
+      { role: 'traitor', card: 'traitor_01' },
+    ];
+    users.forEach((u, i) => {
+      assignments[u.uid] = { role: bad[i].role, identityCardId: bad[i].card };
+    });
+    await h.expectHttpsError(
+      game.host.call('startGame', { gameId: game.gameId, testSeed: { assignments } }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a seed where a card does not match its declared role', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    const assignments = {};
+    const bad = [
+      { role: 'leader', card: 'leader_01' },
+      { role: 'assassin', card: 'assassin_01' },
+      { role: 'assassin', card: 'guardian_01' }, // wrong role for the card
+      { role: 'traitor', card: 'traitor_01' },
+    ];
+    users.forEach((u, i) => {
+      assignments[u.uid] = { role: bad[i].role, identityCardId: bad[i].card };
+    });
+    await h.expectHttpsError(
+      game.host.call('startGame', { gameId: game.gameId, testSeed: { assignments } }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a seed that hands the same card to two players', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    const assignments = {};
+    const bad = [
+      { role: 'leader', card: 'leader_01' },
+      { role: 'assassin', card: 'assassin_01' },
+      { role: 'assassin', card: 'assassin_01' },
+      { role: 'traitor', card: 'traitor_01' },
+    ];
+    users.forEach((u, i) => {
+      assignments[u.uid] = { role: bad[i].role, identityCardId: bad[i].card };
+    });
+    await h.expectHttpsError(
+      game.host.call('startGame', { gameId: game.gameId, testSeed: { assignments } }),
+      'invalid-argument'
+    );
+  });
+});
+
+describe('startGame — non-treachery game modes', () => {
+  for (const mode of ['none', 'planechase']) {
+    it(`"${mode}" starts without assigning roles or identity cards`, async () => {
+      const users = await h.getUsers(4);
+      const game = await h.seedGame({ users, gameMode: mode, startingLife: 30 });
+
+      await game.host.call('startGame', { gameId: game.gameId });
+
+      const players = await h.getPlayers(game.gameId);
+      for (const p of players) {
+        assert.equal(p.role, null, 'no roles in a non-treachery game');
+        assert.equal(p.identity_card_id, null, 'no identity cards in a non-treachery game');
+        assert.equal(p.life_total, 30);
+      }
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.state, 'in_progress');
+    });
+  }
+
+  it('planechase mode seeds a starting plane', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users, gameMode: 'planechase' });
+    await game.host.call('startGame', { gameId: game.gameId });
+    const g = await h.getGame(game.gameId);
+    assert.ok(g.planechase, 'planechase state must be initialised');
+    assert.ok(g.planechase.current_plane_id, 'a starting plane must be chosen');
+    assert.deepEqual(g.planechase.used_plane_ids, [g.planechase.current_plane_id]);
+    assert.equal(g.planechase.chaotic_aether_active, false);
+  });
+});
+
+describe('startGame — player counts outside the distribution table', () => {
+  // SKIP: currently broken — see finding #F. Un-skip when functions/index.js is fixed.
+  //
+  // getRoleDistribution() falls back to the 4-player distribution (sum = 4) for
+  // any count it does not know, so a 9-player game assigns only 4 roles and the
+  // 5th player gets role `undefined`. That surfaces as an opaque
+  // `internal: Not enough identity cards for role: undefined`.
+  //
+  // Correct expectation: either a real 9-player distribution, or a clear
+  // client-facing error — never `internal`.
+  it(
+    'a 9-player game either deals a real distribution or fails with a clear error',
+    { skip: 'currently broken — see finding #F' },
+    async () => {
+      const users = await h.getUsers(9);
+      const game = await h.seedGame({ users, maxPlayers: 8 });
+
+      let err = null;
+      try {
+        await game.host.call('startGame', { gameId: game.gameId });
+      } catch (e) {
+        err = e;
+      }
+
+      if (err) {
+        const code = String(err.code || '').replace(/^functions\//, '');
+        assert.ok(
+          ['failed-precondition', 'invalid-argument'].includes(code),
+          `expected a clear client error, got "${code}": ${err.message}`
+        );
+        const g = await h.getGame(game.gameId);
+        assert.equal(g.state, 'waiting', 'a failed start must roll back');
+        return;
+      }
+
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(players.length, 9);
+      const counts = h.roleCounts(players);
+      assert.equal(
+        counts.leader + counts.guardian + counts.assassin + counts.traitor,
+        9,
+        'every player must receive a role'
+      );
+      assert.equal(counts.leader, 1, 'exactly one leader');
+      assert.equal(
+        new Set(players.map((p) => p.identity_card_id)).size,
+        9,
+        'identity cards must be unique'
+      );
+    }
+  );
+});

--- a/functions/test/integration/callables/traitor-abilities.test.js
+++ b/functions/test/integration/callables/traitor-abilities.test.js
@@ -1,0 +1,654 @@
+'use strict';
+
+/**
+ * INTEGRATION: the three "special" traitor callables —
+ *   exports.resolveMetamorph      (The Metamorph,       traitor_07)
+ *   exports.resolvePuppetMaster   (The Puppet Master,   traitor_09)
+ *   exports.resolveWearerOfMasks  (The Wearer of Masks, traitor_13)
+ *
+ * Games are set up through the real startGame testSeed hook, then advanced
+ * with the real unveilPlayer / adjustLife callables wherever the rules allow
+ * it. firebase-admin is used to force a state the rules cannot reach on their
+ * own (e.g. an eliminated Leader in a game that has not finished).
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+const LEADER = { role: 'leader', card: 'leader_01' };
+const ASSASSIN_A = { role: 'assassin', card: 'assassin_01' };
+const ASSASSIN_B = { role: 'assassin', card: 'assassin_02' };
+
+/** 4-player game whose single traitor holds `traitorCard`. */
+async function gameWithTraitor(traitorCard) {
+  const users = await h.getUsers(4);
+  const game = await h.seedStartedGame({
+    users,
+    seats: [LEADER, ASSASSIN_A, ASSASSIN_B, { role: 'traitor', card: traitorCard }],
+  });
+  return { ...game, traitor: users[3] };
+}
+
+/**
+ * Eliminates a player through the real adjustLife callable. Callers must pick
+ * a seat whose removal does not satisfy a win condition, or the game finishes.
+ */
+function eliminate(game, playerId) {
+  return game.users[0].call('adjustLife', {
+    gameId: game.gameId,
+    playerId,
+    amount: -1000,
+  });
+}
+
+// ════════════════════════════════════════════════════════════════
+// The Metamorph — traitor_07
+// ════════════════════════════════════════════════════════════════
+
+describe('resolveMetamorph — guards', () => {
+  it("rejects a caller whose card is not The Metamorph", async () => {
+    const game = await gameWithTraitor('traitor_01');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    await eliminate(game, 'p2');
+
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p2',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a Metamorph who has not unveiled', async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await eliminate(game, 'p2');
+
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p2',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a target who is still alive', async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p1',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it("rejects stealing the Leader's identity", async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    // Seeded directly: eliminating the Leader for real would immediately end
+    // the game, and this test is about the Leader-card guard, not win state.
+    await h.patchPlayer(game.gameId, 'p0', {
+      is_eliminated: true,
+      is_unveiled: true,
+      life_total: 0,
+    });
+
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p0',
+      }),
+      'failed-precondition'
+    );
+    const metamorph = await h.getPlayer(game.gameId, 'p3');
+    assert.equal(metamorph.identity_card_id, 'traitor_07');
+    assert.equal(metamorph.role, 'traitor');
+  });
+
+  it('rejects an unknown target', async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'nope',
+      }),
+      'not-found'
+    );
+  });
+
+  it('rejects a missing targetPlayerId', async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await h.expectHttpsError(
+      game.traitor.call('resolveMetamorph', { gameId: game.gameId }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a caller who is not in the game', async () => {
+    const users = await h.getUsers(5);
+    const game = await h.seedStartedGame({
+      users: users.slice(0, 4),
+      seats: [LEADER, ASSASSIN_A, ASSASSIN_B, { role: 'traitor', card: 'traitor_07' }],
+    });
+    await h.expectHttpsError(
+      users[4].call('resolveMetamorph', { gameId: game.gameId, targetPlayerId: 'p2' }),
+      'not-found'
+    );
+  });
+
+  it('rejects use before the game is in progress', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      users[3].call('resolveMetamorph', { gameId: game.gameId, targetPlayerId: 'p2' }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p2',
+      }),
+      'unauthenticated'
+    );
+  });
+});
+
+describe('resolveMetamorph — stealing an eliminated identity', () => {
+  it("adopts the target's card AND role", async () => {
+    const game = await gameWithTraitor('traitor_07');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    await eliminate(game, 'p2');
+
+    const res = await game.traitor.call('resolveMetamorph', {
+      gameId: game.gameId,
+      targetPlayerId: 'p2',
+    });
+    assert.equal(res.success, true);
+    assert.equal(res.newCardId, 'assassin_02');
+    assert.equal(res.isFaceDown, true);
+
+    const metamorph = await h.getPlayer(game.gameId, 'p3');
+    assert.equal(metamorph.identity_card_id, 'assassin_02');
+    assert.equal(metamorph.role, 'assassin', 'the role follows the stolen card');
+    assert.equal(metamorph.is_face_down, true);
+    assert.equal(metamorph.original_identity_card_id, 'traitor_07');
+    assert.equal(metamorph.original_role, 'traitor');
+  });
+
+  // SKIP: currently broken — see finding #D. Un-skip when functions/index.js is fixed.
+  //
+  // resolveMetamorph (index.js ~857) only writes the caller's doc; the target
+  // keeps its identity_card_id, so the stolen card exists twice on the table.
+  // Two players holding the same identity corrupts every downstream reader
+  // (Puppet Master's "already assigned" guard, Wearer of Masks' "already in
+  // the game" guard, and the win-condition role tally).
+  it(
+    'leaves exactly one copy of every identity card in play',
+    { skip: 'currently broken — see finding #D' },
+    async () => {
+      const game = await gameWithTraitor('traitor_07');
+      await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+      await eliminate(game, 'p2');
+
+      await game.traitor.call('resolveMetamorph', {
+        gameId: game.gameId,
+        targetPlayerId: 'p2',
+      });
+
+      const players = await h.getPlayers(game.gameId);
+      const cardIds = players.map((p) => p.identity_card_id).filter(Boolean);
+      assert.equal(
+        new Set(cardIds).size,
+        cardIds.length,
+        `no two players may hold the same identity card, got ${cardIds.join(', ')}`
+      );
+    }
+  );
+
+  // SKIP: currently broken — see finding #D. Un-skip when functions/index.js is fixed.
+  //
+  // There is no is_eliminated guard on the caller. Elimination sets
+  // is_unveiled = true, so a dead Metamorph sails straight through the only
+  // gate the function has and steals a card from beyond the grave.
+  it(
+    'cannot be used by an eliminated Metamorph',
+    { skip: 'currently broken — see finding #D' },
+    async () => {
+      const game = await gameWithTraitor('traitor_07');
+      await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+      await eliminate(game, 'p2');
+      await eliminate(game, 'p3');
+
+      await h.expectHttpsError(
+        game.traitor.call('resolveMetamorph', {
+          gameId: game.gameId,
+          targetPlayerId: 'p2',
+        }),
+        'failed-precondition'
+      );
+      const metamorph = await h.getPlayer(game.gameId, 'p3');
+      assert.equal(metamorph.identity_card_id, 'traitor_07');
+    }
+  );
+});
+
+// ════════════════════════════════════════════════════════════════
+// The Puppet Master — traitor_09
+// ════════════════════════════════════════════════════════════════
+
+async function unveiledPuppetMaster() {
+  const game = await gameWithTraitor('traitor_09');
+  await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+  return game;
+}
+
+describe('resolvePuppetMaster — guards', () => {
+  it('rejects a caller whose card is not The Puppet Master', async () => {
+    const game = await gameWithTraitor('traitor_01');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a Puppet Master who has not unveiled', async () => {
+    const game = await gameWithTraitor('traitor_09');
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects redistributing the caller\'s own card', async () => {
+    const game = await unveiledPuppetMaster();
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p3: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects redistributing to an eliminated player', async () => {
+    const game = await unveiledPuppetMaster();
+    await eliminate(game, 'p2');
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p2: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects handing the same card to two players', async () => {
+    const game = await unveiledPuppetMaster();
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_01', p2: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players[1].identity_card_id, 'assassin_01');
+    assert.equal(players[2].identity_card_id, 'assassin_02');
+  });
+
+  it('rejects an unknown player id', async () => {
+    const game = await unveiledPuppetMaster();
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { ghost: 'assassin_01' },
+      }),
+      'not-found'
+    );
+  });
+
+  it('rejects a missing redistributions map', async () => {
+    const game = await unveiledPuppetMaster();
+    await h.expectHttpsError(
+      game.traitor.call('resolvePuppetMaster', { gameId: game.gameId }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects use before the game is in progress', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      users[3].call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_01' },
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const game = await unveiledPuppetMaster();
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+      }),
+      'unauthenticated'
+    );
+  });
+});
+
+describe('resolvePuppetMaster — redistribution', () => {
+  it('swaps two in-play identities and carries the roles with them', async () => {
+    const game = await unveiledPuppetMaster();
+
+    const res = await game.traitor.call('resolvePuppetMaster', {
+      gameId: game.gameId,
+      redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+    });
+    assert.deepEqual(res, { success: true });
+
+    const players = await h.getPlayers(game.gameId);
+    assert.equal(players[1].identity_card_id, 'assassin_02');
+    assert.equal(players[1].role, 'assassin');
+    assert.equal(players[1].is_face_down, true);
+    assert.equal(players[1].original_identity_card_id, 'assassin_01');
+    assert.equal(players[1].original_role, 'assassin');
+
+    assert.equal(players[2].identity_card_id, 'assassin_01');
+    assert.equal(players[2].original_identity_card_id, 'assassin_02');
+
+    assert.equal(players[0].identity_card_id, 'leader_01', 'the Leader is untouched');
+    assert.equal(players[3].identity_card_id, 'traitor_09', 'the caller keeps their card');
+  });
+
+  // SKIP: currently broken — see finding #C. Un-skip when functions/index.js is fixed.
+  //
+  // resolvePuppetMaster (index.js ~922) accepts ANY id from identityCards.json.
+  // The card only has to exist — it does not have to be in the game — so the
+  // Puppet Master can conjure the other ~58 identities out of the box.
+  it(
+    'rejects assigning a card that is not currently in play',
+    { skip: 'currently broken — see finding #C' },
+    async () => {
+      const game = await unveiledPuppetMaster();
+
+      await h.expectHttpsError(
+        game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p1: 'assassin_15' },
+        }),
+        'invalid-argument'
+      );
+      const p1 = await h.getPlayer(game.gameId, 'p1');
+      assert.equal(p1.identity_card_id, 'assassin_01');
+    }
+  );
+
+  // SKIP: currently broken — see finding #C. Un-skip when functions/index.js is fixed.
+  //
+  // Nothing checks that the result is a permutation of the identities already
+  // on the table, so the Leader's card can be duplicated onto a second player
+  // and the game ends up with two Leaders.
+  it(
+    'rejects creating a second Leader',
+    { skip: 'currently broken — see finding #C' },
+    async () => {
+      const game = await unveiledPuppetMaster();
+
+      await h.expectHttpsError(
+        game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p1: 'leader_01' },
+        }),
+        'invalid-argument'
+      );
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(
+        players.filter((p) => p.role === 'leader').length,
+        1,
+        'a game must never contain two Leaders'
+      );
+    }
+  );
+
+  // SKIP: currently broken — see finding #C. Un-skip when functions/index.js is fixed.
+  //
+  // The mirror image: the Leader can be handed a non-Leader identity, which
+  // silently deletes the Leader from the game and hands the assassins the win
+  // on the next elimination check.
+  it(
+    'rejects turning the Leader into a non-Leader',
+    { skip: 'currently broken — see finding #C' },
+    async () => {
+      const game = await unveiledPuppetMaster();
+
+      await h.expectHttpsError(
+        game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p0: 'assassin_01' },
+        }),
+        'invalid-argument'
+      );
+      const leader = await h.getPlayer(game.gameId, 'p0');
+      assert.equal(leader.role, 'leader');
+      assert.equal(leader.identity_card_id, 'leader_01');
+    }
+  );
+
+  // SKIP: currently broken — see finding #C. Un-skip when functions/index.js is fixed.
+  //
+  // There is no is_eliminated guard on the caller, and elimination sets
+  // is_unveiled = true, so the only gate the function has is already satisfied.
+  it(
+    'cannot be used by an eliminated Puppet Master',
+    { skip: 'currently broken — see finding #C' },
+    async () => {
+      const game = await unveiledPuppetMaster();
+      await eliminate(game, 'p3');
+
+      await h.expectHttpsError(
+        game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+        }),
+        'failed-precondition'
+      );
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(players[1].identity_card_id, 'assassin_01');
+      assert.equal(players[2].identity_card_id, 'assassin_02');
+    }
+  );
+
+  // SKIP: currently broken — see finding #C. Un-skip when functions/index.js is fixed.
+  //
+  // The Puppet Master's unveil ability is a one-shot, but nothing records that
+  // it has been used, so it can be replayed for the rest of the game.
+  it(
+    'can only be resolved once',
+    { skip: 'currently broken — see finding #C' },
+    async () => {
+      const game = await unveiledPuppetMaster();
+
+      await game.traitor.call('resolvePuppetMaster', {
+        gameId: game.gameId,
+        redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+      });
+
+      await h.expectHttpsError(
+        game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p1: 'assassin_01', p2: 'assassin_02' },
+        }),
+        'failed-precondition'
+      );
+    }
+  );
+});
+
+// ════════════════════════════════════════════════════════════════
+// The Wearer of Masks — traitor_13
+// ════════════════════════════════════════════════════════════════
+
+async function unveiledWearer() {
+  const game = await gameWithTraitor('traitor_13');
+  await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+  return game;
+}
+
+describe('resolveWearerOfMasks', () => {
+  it('becomes a card from outside the game while staying a traitor', async () => {
+    const game = await unveiledWearer();
+
+    const res = await game.traitor.call('resolveWearerOfMasks', {
+      gameId: game.gameId,
+      chosenCardId: 'assassin_15',
+    });
+    assert.deepEqual(res, { success: true, newCardId: 'assassin_15' });
+
+    const wearer = await h.getPlayer(game.gameId, 'p3');
+    assert.equal(wearer.identity_card_id, 'assassin_15');
+    assert.equal(wearer.role, 'traitor', 'the Wearer of Masks stays a traitor');
+    assert.equal(wearer.original_identity_card_id, 'traitor_13');
+  });
+
+  it('accepts declining the ability', async () => {
+    const game = await unveiledWearer();
+    const res = await game.traitor.call('resolveWearerOfMasks', {
+      gameId: game.gameId,
+      chosenCardId: null,
+    });
+    assert.deepEqual(res, { success: true, declined: true });
+
+    const wearer = await h.getPlayer(game.gameId, 'p3');
+    assert.equal(wearer.identity_card_id, 'traitor_13');
+  });
+
+  it('rejects a Leader card', async () => {
+    const game = await unveiledWearer();
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'leader_02',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a card that is already in the game', async () => {
+    const game = await unveiledWearer();
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_01',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a card id that does not exist', async () => {
+    const game = await unveiledWearer();
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_99',
+      }),
+      'not-found'
+    );
+  });
+
+  it('rejects a caller whose card is not The Wearer of Masks', async () => {
+    const game = await gameWithTraitor('traitor_01');
+    await game.traitor.call('unveilPlayer', { gameId: game.gameId });
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_15',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a Wearer who has not unveiled', async () => {
+    const game = await gameWithTraitor('traitor_13');
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_15',
+      }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const game = await unveiledWearer();
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_15',
+      }),
+      'unauthenticated'
+    );
+  });
+
+  // SKIP: currently broken — see finding #E. Un-skip when functions/index.js is fixed.
+  //
+  // resolveWearerOfMasks (index.js ~1007) only blocks Leader cards and cards
+  // already in play. traitor_09 is neither, so the Wearer can simply *become*
+  // The Puppet Master — and resolvePuppetMaster's sole identity gate is
+  // `identity_card_id === "traitor_09"`, which now passes. One unveil turns
+  // into the strongest table-warping ability in the game.
+  it(
+    'copying traitor_09 must not grant Puppet Master powers',
+    { skip: 'currently broken — see finding #E' },
+    async () => {
+      const game = await unveiledWearer();
+
+      let escalated = false;
+      try {
+        await game.traitor.call('resolveWearerOfMasks', {
+          gameId: game.gameId,
+          chosenCardId: 'traitor_09',
+        });
+        await game.traitor.call('resolvePuppetMaster', {
+          gameId: game.gameId,
+          redistributions: { p1: 'assassin_02', p2: 'assassin_01' },
+        });
+        escalated = true;
+      } catch {
+        // Blocked at one of the two steps — that is the correct behaviour.
+      }
+
+      assert.equal(
+        escalated,
+        false,
+        'becoming traitor_09 via Wearer of Masks must not unlock resolvePuppetMaster'
+      );
+      const players = await h.getPlayers(game.gameId);
+      assert.equal(players[1].identity_card_id, 'assassin_01');
+      assert.equal(players[2].identity_card_id, 'assassin_02');
+    }
+  );
+});

--- a/functions/test/integration/callables/traitor-rarity.test.js
+++ b/functions/test/integration/callables/traitor-rarity.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * INTEGRATION: max_traitor_rarity cap (startGame + updateGameSettings)
+ *
+ * The cap is statistical by nature, so the capped cases are run over many
+ * real games rather than a single draw.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+const SEATS_4P = 4;
+const ROUNDS = 25;
+const CHUNK = 5;
+
+/**
+ * Starts `rounds` independent 4-player games (in small parallel batches so the
+ * emulator is not hammered) and returns the traitor's identity card from each.
+ */
+async function drawTraitors(rounds, { maxTraitorRarity } = {}) {
+  const users = await h.getUsers(SEATS_4P);
+  const drawn = [];
+
+  for (let start = 0; start < rounds; start += CHUNK) {
+    const size = Math.min(CHUNK, rounds - start);
+    // eslint-disable-next-line no-await-in-loop
+    const games = await Promise.all(
+      Array.from({ length: size }, () => h.seedGame({ users, maxTraitorRarity }))
+    );
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(
+      games.map((g) => g.host.call('startGame', { gameId: g.gameId }))
+    );
+    // eslint-disable-next-line no-await-in-loop
+    const rosters = await Promise.all(games.map((g) => h.getPlayers(g.gameId)));
+    for (const players of rosters) {
+      const traitors = players.filter((p) => p.role === 'traitor');
+      assert.equal(traitors.length, 1, 'a 4-player game has exactly one traitor');
+      drawn.push(traitors[0].identity_card_id);
+    }
+  }
+  return drawn;
+}
+
+describe('max_traitor_rarity — startGame honours the cap', () => {
+  it(`caps the traitor pool to the 4 uncommon traitors over ${ROUNDS} games`, async () => {
+    const drawn = await drawTraitors(ROUNDS, { maxTraitorRarity: 'uncommon' });
+    assert.equal(drawn.length, ROUNDS);
+    for (const cardId of drawn) {
+      assert.ok(
+        h.UNCOMMON_TRAITORS.includes(cardId),
+        `traitor ${cardId} (rarity ${h.cardById(cardId)?.rarity}) exceeds the "uncommon" cap`
+      );
+    }
+  });
+
+  it(`caps the traitor pool to uncommon+rare over ${ROUNDS} games`, async () => {
+    const drawn = await drawTraitors(ROUNDS, { maxTraitorRarity: 'rare' });
+    assert.equal(drawn.length, ROUNDS);
+    for (const cardId of drawn) {
+      const rarity = h.cardById(cardId)?.rarity;
+      assert.ok(
+        ['uncommon', 'rare'].includes(rarity),
+        `traitor ${cardId} has rarity "${rarity}", which exceeds the "rare" cap`
+      );
+    }
+  });
+
+  it(`draws from the full traitor pool when no cap is set (${ROUNDS} games)`, async () => {
+    const drawn = await drawTraitors(ROUNDS);
+    assert.equal(drawn.length, ROUNDS);
+    for (const cardId of drawn) {
+      const card = h.cardById(cardId);
+      assert.ok(card && card.role === 'traitor', `${cardId} must be a traitor card`);
+    }
+    // 9 of the 13 traitors are above uncommon; the odds of never drawing one of
+    // them in 25 uncapped games are (4/13)^25 ~= 3e-13, so this is a safe
+    // assertion that the cap is genuinely absent rather than silently applied.
+    const sawHigherRarity = drawn.some(
+      (id) => !h.UNCOMMON_TRAITORS.includes(id)
+    );
+    assert.ok(
+      sawHigherRarity,
+      `expected at least one non-uncommon traitor across ${ROUNDS} uncapped games, got ${drawn.join(', ')}`
+    );
+  });
+
+  it('honours a cap that the host set through updateGameSettings', async () => {
+    const users = await h.getUsers(SEATS_4P);
+    const game = await h.seedGame({ users });
+
+    await game.host.call('updateGameSettings', {
+      gameId: game.gameId,
+      maxTraitorRarity: 'uncommon',
+    });
+    const beforeStart = await h.getGame(game.gameId);
+    assert.equal(beforeStart.max_traitor_rarity, 'uncommon');
+
+    await game.host.call('startGame', { gameId: game.gameId });
+
+    const players = await h.getPlayers(game.gameId);
+    const traitor = players.find((p) => p.role === 'traitor');
+    assert.ok(
+      h.UNCOMMON_TRAITORS.includes(traitor.identity_card_id),
+      `traitor ${traitor.identity_card_id} exceeds the cap set via updateGameSettings`
+    );
+  });
+});
+
+describe('max_traitor_rarity — updateGameSettings validation', () => {
+  for (const rarity of ['uncommon', 'rare', 'mythic', 'special']) {
+    it(`accepts and persists "${rarity}"`, async () => {
+      const users = await h.getUsers(2);
+      const game = await h.seedGame({ users });
+      await game.host.call('updateGameSettings', {
+        gameId: game.gameId,
+        maxTraitorRarity: rarity,
+      });
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.max_traitor_rarity, rarity);
+    });
+  }
+
+  for (const bad of ['common', 'SPECIAL', 'constructor', 'toString', '', 'legendary']) {
+    it(`rejects ${JSON.stringify(bad)} with invalid-argument`, async () => {
+      const users = await h.getUsers(2);
+      const game = await h.seedGame({ users });
+      await h.expectHttpsError(
+        game.host.call('updateGameSettings', {
+          gameId: game.gameId,
+          maxTraitorRarity: bad,
+        }),
+        'invalid-argument'
+      );
+      const g = await h.getGame(game.gameId);
+      assert.equal(
+        g.max_traitor_rarity,
+        undefined,
+        'a rejected rarity must not be written'
+      );
+    });
+  }
+
+  for (const bad of [123, null, true]) {
+    it(`rejects the non-string value ${JSON.stringify(bad)}`, async () => {
+      const users = await h.getUsers(2);
+      const game = await h.seedGame({ users });
+      await h.expectHttpsError(
+        game.host.call('updateGameSettings', {
+          gameId: game.gameId,
+          maxTraitorRarity: bad,
+        }),
+        'invalid-argument'
+      );
+    });
+  }
+});

--- a/functions/test/integration/callables/unveil.test.js
+++ b/functions/test/integration/callables/unveil.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.unveilPlayer (functions/index.js)
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+const SEATS_4P = [
+  { role: 'leader', card: 'leader_01' },
+  { role: 'assassin', card: 'assassin_01' },
+  { role: 'assassin', card: 'assassin_02' },
+  { role: 'traitor', card: 'traitor_01' },
+];
+
+function startedGame(users) {
+  return h.seedStartedGame({ users, seats: SEATS_4P });
+}
+
+describe('unveilPlayer', () => {
+  it('unveils the caller', async () => {
+    const users = await h.getUsers(4);
+    const game = await startedGame(users);
+
+    const res = await users[1].call('unveilPlayer', { gameId: game.gameId });
+    assert.deepEqual(res, { success: true });
+
+    const p = await h.getPlayer(game.gameId, 'p1');
+    assert.equal(p.is_unveiled, true);
+    assert.equal(p.identity_card_id, 'assassin_01', 'unveiling does not change the card');
+    assert.equal(p.role, 'assassin', 'unveiling does not change the role');
+
+    const others = await h.getPlayers(game.gameId);
+    assert.deepEqual(
+      others.filter((o) => o.id !== 'p1').map((o) => o.is_unveiled),
+      [false, false, false],
+      'unveiling one player must not unveil anyone else'
+    );
+  });
+
+  it('rejects a double unveil', async () => {
+    const users = await h.getUsers(4);
+    const game = await startedGame(users);
+    await users[3].call('unveilPlayer', { gameId: game.gameId });
+    await h.expectHttpsError(
+      users[3].call('unveilPlayer', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects the Leader, whose identity is always public', async () => {
+    const users = await h.getUsers(4);
+    const game = await startedGame(users);
+    await h.expectHttpsError(
+      users[0].call('unveilPlayer', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+    const p = await h.getPlayer(game.gameId, 'p0');
+    assert.equal(p.is_unveiled, false);
+  });
+
+  it('rejects an eliminated player', async () => {
+    const users = await h.getUsers(4);
+    const game = await startedGame(users);
+    // Eliminate without the elimination's automatic unveil, so the test hits
+    // the is_eliminated gate rather than the is_unveiled one.
+    await h.patchPlayer(game.gameId, 'p2', { is_eliminated: true, life_total: 0 });
+
+    await h.expectHttpsError(
+      users[2].call('unveilPlayer', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+    const p = await h.getPlayer(game.gameId, 'p2');
+    assert.equal(p.is_unveiled, false);
+  });
+
+  it('rejects a caller who is not in the game', async () => {
+    const users = await h.getUsers(5);
+    const game = await startedGame(users.slice(0, 4));
+    await h.expectHttpsError(
+      users[4].call('unveilPlayer', { gameId: game.gameId }),
+      'not-found'
+    );
+  });
+
+  it('rejects unveiling before the game starts', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      users[1].call('unveilPlayer', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects an unknown gameId', async () => {
+    const [user] = await h.getUsers(1);
+    await h.expectHttpsError(
+      user.call('unveilPlayer', { gameId: 'nope' }),
+      'not-found'
+    );
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const users = await h.getUsers(4);
+    const game = await startedGame(users);
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('unveilPlayer', { gameId: game.gameId }),
+      'unauthenticated'
+    );
+  });
+});

--- a/functions/test/integration/callables/update-game-settings.test.js
+++ b/functions/test/integration/callables/update-game-settings.test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.updateGameSettings (functions/index.js)
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+describe('updateGameSettings — authorisation & preconditions', () => {
+  it('rejects a non-host with permission-denied', async () => {
+    const users = await h.getUsers(3);
+    const game = await h.seedGame({ users, maxPlayers: 8 });
+    await h.expectHttpsError(
+      users[1].call('updateGameSettings', { gameId: game.gameId, maxPlayers: 4 }),
+      'permission-denied'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.max_players, 8, 'a rejected update must not persist');
+  });
+
+  it('rejects changes once the game is no longer waiting', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users, maxPlayers: 8 });
+    await game.host.call('startGame', { gameId: game.gameId });
+
+    await h.expectHttpsError(
+      game.host.call('updateGameSettings', { gameId: game.gameId, maxPlayers: 4 }),
+      'failed-precondition'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.max_players, 8);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users });
+    await h.expectHttpsError(
+      h.unauthenticatedCaller()('updateGameSettings', {
+        gameId: game.gameId,
+        maxPlayers: 4,
+      }),
+      'unauthenticated'
+    );
+  });
+
+  it('rejects an unknown gameId', async () => {
+    const [host] = await h.getUsers(1);
+    await h.expectHttpsError(
+      host.call('updateGameSettings', { gameId: 'nope', maxPlayers: 4 }),
+      'not-found'
+    );
+  });
+
+  it('rejects a missing gameId', async () => {
+    const [host] = await h.getUsers(1);
+    await h.expectHttpsError(host.call('updateGameSettings', {}), 'invalid-argument');
+  });
+});
+
+describe('updateGameSettings — maxPlayers', () => {
+  it('persists a valid value', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users, maxPlayers: 8 });
+    const res = await game.host.call('updateGameSettings', {
+      gameId: game.gameId,
+      maxPlayers: 6,
+    });
+    assert.deepEqual(res, { success: true });
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.max_players, 6);
+  });
+
+  for (const bad of [1, 9, 0, -3]) {
+    it(`rejects ${bad}`, async () => {
+      const users = await h.getUsers(2);
+      const game = await h.seedGame({ users, maxPlayers: 8 });
+      await h.expectHttpsError(
+        game.host.call('updateGameSettings', { gameId: game.gameId, maxPlayers: bad }),
+        'invalid-argument'
+      );
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.max_players, 8);
+    });
+  }
+});
+
+describe('updateGameSettings — gameMode', () => {
+  for (const mode of ['treachery', 'planechase', 'treachery_planechase', 'none']) {
+    it(`persists "${mode}"`, async () => {
+      const users = await h.getUsers(2);
+      const game = await h.seedGame({ users, gameMode: 'treachery' });
+      await game.host.call('updateGameSettings', { gameId: game.gameId, gameMode: mode });
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.game_mode, mode);
+    });
+  }
+
+  it('rejects an unknown mode', async () => {
+    const users = await h.getUsers(2);
+    const game = await h.seedGame({ users, gameMode: 'treachery' });
+    await h.expectHttpsError(
+      game.host.call('updateGameSettings', { gameId: game.gameId, gameMode: 'chess' }),
+      'invalid-argument'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.game_mode, 'treachery');
+  });
+});
+
+describe('updateGameSettings — startingLife', () => {
+  for (const bad of [35, 0, 41, -20]) {
+    it(`rejects the unsupported value ${bad}`, async () => {
+      const users = await h.getUsers(3);
+      const game = await h.seedGame({ users, startingLife: 40 });
+      await h.expectHttpsError(
+        game.host.call('updateGameSettings', { gameId: game.gameId, startingLife: bad }),
+        'invalid-argument'
+      );
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.starting_life, 40);
+    });
+  }
+
+  // SKIP: currently broken — see finding #A. Un-skip when functions/index.js is fixed.
+  //
+  // index.js ~1483 writes with `tx.update(gameRef, update)` and then reads the
+  // players subcollection at ~1487. Firestore transactions require every read
+  // to precede every write, so the SDK throws and the whole transaction is
+  // rolled back: passing startingLife ALWAYS fails with `internal`.
+  for (const life of [20, 25, 30, 50]) {
+    it(
+      `sets starting_life to ${life} and re-bases every player's life_total`,
+      { skip: 'currently broken — see finding #A' },
+      async () => {
+        const users = await h.getUsers(3);
+        const game = await h.seedGame({ users, startingLife: 40 });
+
+        const res = await game.host.call('updateGameSettings', {
+          gameId: game.gameId,
+          startingLife: life,
+        });
+        assert.deepEqual(res, { success: true });
+
+        const g = await h.getGame(game.gameId);
+        assert.equal(g.starting_life, life);
+
+        const players = await h.getPlayers(game.gameId);
+        assert.equal(players.length, 3);
+        for (const p of players) {
+          assert.equal(p.life_total, life, `${p.id} life_total must follow starting_life`);
+        }
+      }
+    );
+  }
+
+  // SKIP: currently broken — see finding #A. Un-skip when functions/index.js is fixed.
+  //
+  // Because the transaction throws, any setting co-submitted with startingLife
+  // is rolled back too — a host changing life + max players in one save loses
+  // BOTH changes.
+  it(
+    'persists every setting co-submitted with startingLife',
+    { skip: 'currently broken — see finding #A' },
+    async () => {
+      const users = await h.getUsers(3);
+      const game = await h.seedGame({
+        users,
+        startingLife: 40,
+        maxPlayers: 8,
+        gameMode: 'treachery',
+      });
+
+      await game.host.call('updateGameSettings', {
+        gameId: game.gameId,
+        startingLife: 25,
+        maxPlayers: 5,
+        gameMode: 'treachery_planechase',
+        maxTraitorRarity: 'rare',
+      });
+
+      const g = await h.getGame(game.gameId);
+      assert.equal(g.starting_life, 25);
+      assert.equal(g.max_players, 5);
+      assert.equal(g.game_mode, 'treachery_planechase');
+      assert.equal(g.max_traitor_rarity, 'rare');
+
+      const players = await h.getPlayers(game.gameId);
+      for (const p of players) assert.equal(p.life_total, 25);
+    }
+  );
+
+  // SKIP: currently broken — see finding #A. Un-skip when functions/index.js is fixed.
+  //
+  // The re-based starting life must be what startGame deals out.
+  it(
+    'a startingLife change is reflected in the life totals startGame deals',
+    { skip: 'currently broken — see finding #A' },
+    async () => {
+      const users = await h.getUsers(4);
+      const game = await h.seedGame({ users, startingLife: 40 });
+
+      await game.host.call('updateGameSettings', { gameId: game.gameId, startingLife: 30 });
+      await game.host.call('startGame', { gameId: game.gameId });
+
+      const players = await h.getPlayers(game.gameId);
+      for (const p of players) {
+        const card = h.cardById(p.identity_card_id);
+        assert.equal(p.life_total, 30 + (card.life_modifier || 0));
+      }
+    }
+  );
+});


### PR DESCRIPTION
**PR 3 of 4.** Base is `test/firestore-rules` (PR #91).

### The gap this closes
`functions/test/game-logic.test.js` has 109 passing tests but `require`s only the two JSON data files — **never `../index.js`**. It re-implements the logic it checks, so it validates a *copy*. That is precisely why a completely dead code path (first row below) sat green indefinitely.

This suite invokes the **real exported callables** against the emulator. Each test user is a genuine anonymous Auth account on its own `firebase/app` instance, so `request.auth.uid` is populated as in production and every auth/permission branch is actually exercised. `firebase-admin` is used only to seed fixtures and read state back.

**138 tests — 119 passing, 19 skipped, ~72s.**

Passing coverage: role distribution for 4–8 players, unique card dealing, `life_total` including card modifiers, the `max_traitor_rarity` cap across 25+ randomized games, host-only and game-state guards, capacity, host promotion, and each treachery win condition.

### The 19 skips
Verified by stripping every skip and re-running: exactly the expected set fails, with the predicted errors.

| Bug | Effect |
|---|---|
| `updateGameSettings` reads after a write in its transaction | **any** starting-life change throws, and silently rolls back every setting submitted with it — the feature is dead on arrival |
| `checkWinConditions` runs for every game mode | Planechase and Life Tracker have no roles, so it falls through to `"assassin"` — the first player to hit 0 life ends the game for the whole table |
| `resolvePuppetMaster` | accepts any card id, doesn't require a permutation of cards in play, never checks the caller is uneliminated or that it's already been used |
| `resolveMetamorph` | never clears the stolen card from its target, so two players hold the same identity |
| `resolveWearerOfMasks` | a player can copy `traitor_09` and inherit Puppet Master powers |

### New bug found, not previously reported
`leaveGame` deletes a player doc without renumbering survivors, while `joinGame` derives a seat from the player count. Seats 0,1,2 minus seat 1 leaves 0,2 — length 2 — so the next joiner is **also** given seat 2. Reproduced: `order_id must stay unique, got 0, 2, 2`. Every `orderBy("order_id")` read then becomes non-deterministic between the colliding pair: `startGame` seating, `leaveGame`'s own host promotion, and `adjustLife`'s win tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)