### PR TITLE
Add a 4-player simulation harness and fill E2E coverage gaps

### DIFF
--- a/Treachery/e2e/concurrency.spec.ts
+++ b/Treachery/e2e/concurrency.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import {
+  LIFE_DEBOUNCE_MS,
+  Role,
+  damage,
+  expectServerLife,
+  fetchPlayerDocs,
+  playersWithRole,
+  setupSeededGame,
+} from './helpers';
+
+/**
+ * Concurrent life adjustments from two different players.
+ *
+ * Real tables do this constantly — two people tap the same victim at once. The
+ * board is optimistic and debounces taps for ~500ms before flushing a single
+ * `adjustLife` call, and the snapshot listener clears a client's *pending*
+ * delta as soon as the server total changes for that player, so a tap made
+ * while someone else's flush is in flight is thrown away before it is ever
+ * sent. The server never hears about it and the total is silently short.
+ *
+ * These tests assert the arithmetic on the server, not on screen: the
+ * optimistic UI can show the right number while the durable total is wrong.
+ */
+
+const LAYOUT: Role[] = ['leader', 'assassin', 'assassin', 'traitor'];
+const STARTING_LIFE = 20;
+
+test.describe('Two players adjusting the same target', () => {
+  test('sequential adjustments from different players both land', async ({ browser }) => {
+    // Baseline: the same two taps, spaced far enough apart that neither
+    // client has a pending delta when the other's update arrives.
+    const { players, gameId } = await setupSeededGame(browser, LAYOUT, {
+      startingLife: STARTING_LIFE,
+    });
+    const [actorA, actorB] = playersWithRole(players, 'assassin');
+    const target = players.find((p) => p.role === 'traitor')!;
+
+    await damage(actorA.page, target.name, 1);
+    await expectServerLife(actorA.page, gameId, target.userId, STARTING_LIFE - 1);
+
+    await damage(actorB.page, target.name, 1);
+    await expectServerLife(actorB.page, gameId, target.userId, STARTING_LIFE - 2);
+  });
+
+  // FIXME: currently broken — see finding #4. Un-fixme when the bug is fixed.
+  // useGameBoard's snapshot listener zeroes `lifeDeltasRef.current[playerId]`
+  // whenever the server total for that player changes, including while this
+  // client still has an un-flushed tap queued. flushLifeDelta then sees 0 and
+  // returns without calling adjustLife, so the second player's damage is lost.
+  // The pending delta should be tracked per in-flight request instead of being
+  // cleared by any incoming snapshot.
+  test.fixme('near-simultaneous adjustments from different players both land', async ({
+    browser,
+  }) => {
+    const { players, gameId } = await setupSeededGame(browser, LAYOUT, {
+      startingLife: STARTING_LIFE,
+    });
+    const [actorA, actorB] = playersWithRole(players, 'assassin');
+    const target = players.find((p) => p.role === 'traitor')!;
+
+    // A taps, then B taps inside A's debounce window. A's flush lands first
+    // and the resulting snapshot wipes B's queued tap.
+    await damage(actorA.page, target.name, 1);
+    await actorB.page.waitForTimeout(LIFE_DEBOUNCE_MS * 0.6);
+    await damage(actorB.page, target.name, 1);
+
+    await expectServerLife(actorA.page, gameId, target.userId, STARTING_LIFE - 2, 15_000);
+  });
+
+  // FIXME: currently broken — see finding #4. Un-fixme when the bug is fixed.
+  // Same root cause, with multi-tap bursts: whichever client's flush lands
+  // second loses its entire accumulated delta, not just one point.
+  test.fixme('overlapping multi-tap bursts from different players both land', async ({
+    browser,
+  }) => {
+    const { players, gameId } = await setupSeededGame(browser, LAYOUT, {
+      startingLife: STARTING_LIFE,
+    });
+    const [actorA, actorB] = playersWithRole(players, 'assassin');
+    const target = players.find((p) => p.role === 'traitor')!;
+
+    await damage(actorA.page, target.name, 3);
+    await actorB.page.waitForTimeout(LIFE_DEBOUNCE_MS * 0.6);
+    await damage(actorB.page, target.name, 4);
+
+    await expectServerLife(actorA.page, gameId, target.userId, STARTING_LIFE - 7, 15_000);
+
+    // And the target is not eliminated by a phantom overshoot either.
+    const docs = await fetchPlayerDocs(actorA.page, gameId);
+    expect(docs.find((d) => d.user_id === target.userId)?.is_eliminated).toBe(false);
+  });
+});

--- a/Treachery/e2e/helpers.ts
+++ b/Treachery/e2e/helpers.ts
@@ -2,6 +2,26 @@ import { Browser, Page, expect } from '@playwright/test';
 
 export type Role = 'leader' | 'guardian' | 'assassin' | 'traitor';
 
+/** Mirrors GameMode in src/models/types.ts. */
+export type GameMode = 'treachery' | 'planechase' | 'treachery_planechase' | 'none';
+
+// The create-game screen labels its mode buttons, not its mode values, so the
+// accessibility label we click is derived from this map (see GAME_MODES in
+// app/(app)/create-game.tsx).
+const MODE_BUTTON_LABEL: Record<GameMode, string> = {
+  treachery: 'Treachery',
+  planechase: 'Planechase',
+  treachery_planechase: 'Both',
+  none: 'Life Tracker',
+};
+
+/** Starting-life values the lobby's updateGameSettings accepts. */
+export const STARTING_LIFE_VALUES = [20, 25, 30, 40, 50] as const;
+export type StartingLife = (typeof STARTING_LIFE_VALUES)[number];
+
+/** The create-game screen's default, used whenever a test doesn't override it. */
+export const DEFAULT_STARTING_LIFE = 40;
+
 export interface RoleAssignment {
   role: Role;
   identityCardId: string;
@@ -16,8 +36,10 @@ export interface PlayerHandle {
   name: string;
   page: Page;
   userId: string;
-  role: Role;
-  identityCardId: string;
+  /** null in non-treachery modes, where startGame assigns no roles. */
+  role: Role | null;
+  /** null in non-treachery modes, where startGame assigns no identity cards. */
+  identityCardId: string | null;
 }
 
 export interface SeededGame {
@@ -25,6 +47,10 @@ export interface SeededGame {
   host: PlayerHandle;
   gameId: string;
   code: string;
+  /** Game mode the lobby was created with — 'treachery' unless overridden. */
+  mode: GameMode;
+  /** starting_life written onto the game doc (before per-card life modifiers). */
+  startingLife: number;
 }
 
 // Role distribution per player count — must mirror getRoleDistribution in
@@ -63,9 +89,42 @@ export async function signInAsGuest(page: Page, displayName?: string) {
   await expect(page.getByRole('button', { name: 'Create game' })).toBeVisible({ timeout: 20_000 });
 }
 
-export async function hostCreateGame(page: Page): Promise<{ gameId: string; code: string }> {
+export interface CreateGameOptions {
+  /** Game mode chip to select on the create screen. Defaults to 'treachery'. */
+  mode?: GameMode;
+  /**
+   * Starting life to dial in with the create screen's stepper (default 40,
+   * ±5 per tap). Lower values keep tests fast: eliminating a player means
+   * clicking `-1` once per point of life.
+   */
+  startingLife?: number;
+}
+
+export async function hostCreateGame(
+  page: Page,
+  options: CreateGameOptions = {},
+): Promise<{ gameId: string; code: string }> {
   await page.getByRole('button', { name: 'Create game' }).click();
   await expect(page).toHaveURL(/\/create-game/);
+
+  if (options.mode && options.mode !== 'treachery') {
+    await page
+      .getByRole('button', { name: `${MODE_BUTTON_LABEL[options.mode]} game mode` })
+      .click();
+  }
+
+  if (options.startingLife !== undefined && options.startingLife !== DEFAULT_STARTING_LIFE) {
+    const delta = options.startingLife - DEFAULT_STARTING_LIFE;
+    if (delta % 5 !== 0) {
+      throw new Error(`startingLife must be a multiple of 5 (got ${options.startingLife})`);
+    }
+    const label = delta < 0 ? 'Decrease starting life' : 'Increase starting life';
+    for (let i = 0; i < Math.abs(delta) / 5; i++) {
+      await page.getByRole('button', { name: label }).click();
+    }
+    await expect(page.getByText(`Starting Life: ${options.startingLife}`)).toBeVisible();
+  }
+
   await page.getByRole('button', { name: 'Create game' }).click();
   await expect(page).toHaveURL(/\/lobby\//);
   const gameId = parseGameIdFromUrl(page.url());
@@ -99,7 +158,7 @@ function parseGameIdFromUrl(url: string): string {
 
 // ── E2E bridge (window.__e2e exposed by firebase config in emulator mode) ──
 
-async function getCurrentUserId(page: Page): Promise<string> {
+export async function getCurrentUserId(page: Page): Promise<string> {
   const uid = await page.evaluate(() => {
     const e2e = (window as unknown as { __e2e?: { getCurrentUserId: () => string | null } }).__e2e;
     if (!e2e) throw new Error('window.__e2e missing — was the bundle built with EXPO_PUBLIC_USE_EMULATOR=true?');
@@ -174,9 +233,112 @@ export function buildTestSeed(
 
 // ── High-level bootstrap ─────────────────────────────────────────
 
-interface SetupOptions {
+export interface SetupOptions {
   /** Map of player index → forced identity card id (e.g. { 3: 'traitor_07' } for the Metamorph). */
   cardOverrides?: Record<number, string>;
+  /** Passed through to the create-game screen's stepper. Defaults to 40. */
+  startingLife?: number;
+}
+
+export interface LobbyHandle {
+  /** One page per player, in join order (index 0 is the host). */
+  pages: Page[];
+  userIds: string[];
+  names: string[];
+  gameId: string;
+  code: string;
+  mode: GameMode;
+  startingLife: number;
+}
+
+/**
+ * Everything up to (but not including) the game start: N guest contexts signed
+ * in as "Player 1".."Player N", player 0 hosting, the rest joined by code.
+ *
+ * Split out of {@link setupSeededGame} so lobby-only specs (host promotion,
+ * settings) can drive the pre-game state without starting anything, and so
+ * non-treachery modes can reuse the same bootstrap.
+ */
+export async function setupLobby(
+  browser: Browser,
+  playerCount: number,
+  options: CreateGameOptions = {},
+): Promise<LobbyHandle> {
+  const contexts = await Promise.all(
+    Array.from({ length: playerCount }, () => browser.newContext()),
+  );
+  const pages = await Promise.all(contexts.map((c) => c.newPage()));
+
+  // Sign all in in parallel, each with a unique display name. The names
+  // ("Player 1", "Player 2", ...) make modal selectors deterministic
+  // (e.g. the Puppet Master swap rows are labeled by display_name).
+  const names = pages.map((_, i) => `Player ${i + 1}`);
+  await Promise.all(pages.map((p, i) => signInAsGuest(p, names[i])));
+
+  const [hostPage, ...guestPages] = pages;
+  const { gameId, code } = await hostCreateGame(hostPage, options);
+  // Join sequentially: joinGame assigns order_id from the current player count
+  // inside a transaction, so parallel joins are safe but the resulting seat
+  // order is not deterministic. Tests index players by seat, so keep it stable.
+  for (const p of guestPages) {
+    await guestJoinGame(p, code);
+  }
+
+  // Wait for the host to see all players in the lobby.
+  await expect(hostPage.getByText(`Players (${playerCount})`)).toBeVisible();
+
+  // Read each player's user_id (preserves the order they joined: host first).
+  const userIds = await Promise.all(pages.map(getCurrentUserId));
+
+  return {
+    pages,
+    userIds,
+    names,
+    gameId,
+    code,
+    mode: options.mode ?? 'treachery',
+    startingLife: options.startingLife ?? DEFAULT_STARTING_LIFE,
+  };
+}
+
+/**
+ * Bootstrap a *non-treachery* game (planechase / Life Tracker) through the real
+ * UI, including the lobby's Start button. There are no roles or identity cards
+ * in these modes, so there's nothing to seed — this is the only path that
+ * exercises startGame's `includesTreachery === false` branch end to end.
+ */
+export async function setupNonTreacheryGame(
+  browser: Browser,
+  playerCount: number,
+  mode: Exclude<GameMode, 'treachery' | 'treachery_planechase'>,
+  options: { startingLife?: number } = {},
+): Promise<SeededGame> {
+  const lobby = await setupLobby(browser, playerCount, { mode, ...options });
+  const [hostPage] = lobby.pages;
+
+  await expect(hostPage.getByRole('button', { name: 'Start game' })).toBeEnabled();
+  await hostPage.getByRole('button', { name: 'Start game' }).click();
+  await Promise.all(
+    lobby.pages.map((p) => expect(p).toHaveURL(/\/game\//, { timeout: 20_000 })),
+  );
+
+  const players: PlayerHandle[] = lobby.pages.map((page, i) => ({
+    name: lobby.names[i],
+    page,
+    userId: lobby.userIds[i],
+    // Non-treachery games leave role/identity_card_id null on every player.
+    role: null,
+    identityCardId: null,
+  }));
+
+  return {
+    players,
+    host: players[0],
+    gameId: lobby.gameId,
+    code: lobby.code,
+    mode,
+    startingLife: lobby.startingLife,
+  };
 }
 
 /**
@@ -210,33 +372,15 @@ export async function setupSeededGame(
     }
   }
 
-  // Spin up contexts and pages, one per player.
-  const contexts = await Promise.all(
-    Array.from({ length: playerCount }, () => browser.newContext()),
+  const { pages, userIds, names, gameId, code, startingLife } = await setupLobby(
+    browser,
+    playerCount,
+    { startingLife: options.startingLife },
   );
-  const pages = await Promise.all(contexts.map((c) => c.newPage()));
-
-  // Sign all in in parallel, each with a unique display name. The names
-  // ("Player 1", "Player 2", ...) make modal selectors deterministic
-  // (e.g. the Puppet Master swap rows are labeled by display_name).
-  await Promise.all(
-    pages.map((p, i) => signInAsGuest(p, `Player ${i + 1}`)),
-  );
-
-  // Host creates, guests join.
-  const [hostPage, ...guestPages] = pages;
-  const { gameId, code } = await hostCreateGame(hostPage);
-  await Promise.all(guestPages.map((p) => guestJoinGame(p, code)));
-
-  // Wait for the host to see all players in the lobby.
-  await expect(hostPage.getByText(`Players (${playerCount})`)).toBeVisible();
-
-  // Read each player's user_id (preserves the order they joined: host first).
-  const userIds = await Promise.all(pages.map(getCurrentUserId));
 
   // Build seed and start the game via the emulator bridge.
   const seed = buildTestSeed(userIds, roles, options.cardOverrides);
-  await callStartGameWithSeed(hostPage, gameId, seed);
+  await callStartGameWithSeed(pages[0], gameId, seed);
 
   // Wait for all players to navigate to the game board.
   await Promise.all(pages.map((p) => expect(p).toHaveURL(/\/game\//, { timeout: 20_000 })));
@@ -245,7 +389,7 @@ export async function setupSeededGame(
     const userId = userIds[i];
     const assignment = seed.assignments[userId];
     return {
-      name: `Player ${i + 1}`, // matches the default display_name pattern after onboarding
+      name: names[i], // matches the display_name set during onboarding
       page,
       userId,
       role: assignment.role,
@@ -253,14 +397,18 @@ export async function setupSeededGame(
     };
   });
 
-  return { players, host: players[0], gameId, code };
+  return { players, host: players[0], gameId, code, mode: 'treachery', startingLife };
 }
 
 // ── In-game actions ──────────────────────────────────────────────
 
 /**
  * Decrease another player's life total by `amount` via the per-row -1 button.
- * Each click fires an `adjustLife` cloud function call.
+ *
+ * NOTE: taps are debounced ~500ms in useGameBoard and collapsed into a single
+ * `adjustLife` call, so N clicks in quick succession are one cloud-function
+ * call of -N. Anything asserting on the *server* total must wait out that
+ * debounce — use {@link expectServerLife}.
  */
 export async function damage(actor: Page, targetName: string, amount: number) {
   const button = actor.getByRole('button', { name: `Decrease ${targetName} life` });
@@ -268,6 +416,17 @@ export async function damage(actor: Page, targetName: string, amount: number) {
     await button.click();
   }
 }
+
+/** Increase another player's life total by `amount` via the per-row +1 button. */
+export async function heal(actor: Page, targetName: string, amount: number) {
+  const button = actor.getByRole('button', { name: `Increase ${targetName} life` });
+  for (let i = 0; i < amount; i++) {
+    await button.click();
+  }
+}
+
+/** How long useGameBoard waits after the last tap before flushing to the server. */
+export const LIFE_DEBOUNCE_MS = 500;
 
 /**
  * Drives a player's life to 0 by clicking -1 enough times. The lobby reads
@@ -316,14 +475,39 @@ export function playersWithRole(players: PlayerHandle[], role: Role): PlayerHand
   return players.filter((p) => p.role === role);
 }
 
+/** Shape of a `/games/{gameId}` doc as read back through the E2E bridge. */
+export interface ServerGame extends Record<string, unknown> {
+  id: string;
+  state?: 'waiting' | 'in_progress' | 'finished';
+  host_id?: string;
+  game_mode?: GameMode;
+  starting_life?: number;
+  winning_team?: Role | null;
+  player_ids?: string[];
+  max_traitor_rarity?: string;
+}
+
+/** Shape of a `/games/{gameId}/players/{playerId}` doc. */
+export interface ServerPlayer {
+  id: string;
+  user_id: string;
+  display_name?: string;
+  order_id?: number;
+  identity_card_id: string | null;
+  role: Role | null;
+  life_total?: number;
+  is_eliminated?: boolean;
+  is_unveiled?: boolean;
+  is_face_down?: boolean;
+  original_identity_card_id?: string | null;
+  original_role?: Role | null;
+}
+
 /**
  * Read the game doc itself using one of the authenticated browser contexts.
  * Useful for asserting host settings (e.g. max_traitor_rarity) persisted.
  */
-export async function fetchGameDoc(
-  page: Page,
-  gameId: string,
-): Promise<(Record<string, unknown> & { max_traitor_rarity?: string }) | null> {
+export async function fetchGameDoc(page: Page, gameId: string): Promise<ServerGame | null> {
   return page.evaluate(
     async ({ gameId }) => {
       const e2e = (window as unknown as {
@@ -333,7 +517,7 @@ export async function fetchGameDoc(
       return e2e.fetchGame(gameId);
     },
     { gameId },
-  ) as Promise<(Record<string, unknown> & { max_traitor_rarity?: string }) | null>;
+  ) as Promise<ServerGame | null>;
 }
 
 /**
@@ -341,15 +525,38 @@ export async function fetchGameDoc(
  * authenticated browser contexts. Useful for asserting on identity-card and
  * is_face_down state after an ability resolves.
  */
-export async function fetchPlayerDocs(
-  page: Page,
-  gameId: string,
-): Promise<Array<{ id: string; user_id: string; identity_card_id: string | null; role: Role | null; is_eliminated?: boolean; is_unveiled?: boolean; is_face_down?: boolean; original_identity_card_id?: string | null; original_role?: Role | null }>> {
+export async function fetchPlayerDocs(page: Page, gameId: string): Promise<ServerPlayer[]> {
   return page.evaluate(async ({ gameId }) => {
     const e2e = (window as unknown as {
       __e2e?: { fetchPlayers: (gid: string) => Promise<unknown[]> };
     }).__e2e;
     if (!e2e) throw new Error('window.__e2e missing');
     return e2e.fetchPlayers(gameId);
-  }, { gameId }) as Promise<Array<{ id: string; user_id: string; identity_card_id: string | null; role: Role | null; is_eliminated?: boolean; is_unveiled?: boolean; is_face_down?: boolean; original_identity_card_id?: string | null; original_role?: Role | null }>>;
+  }, { gameId }) as Promise<ServerPlayer[]>;
+}
+
+/**
+ * Poll the *server* life total for a player until it settles on `expected`.
+ *
+ * The board is optimistic and debounced, so the number rendered in the UI can
+ * be right while the server is still behind (or, when an update is dropped,
+ * right while the server is permanently wrong). Every life assertion that
+ * matters therefore reads Firestore rather than the DOM.
+ */
+export async function expectServerLife(
+  readerPage: Page,
+  gameId: string,
+  userId: string,
+  expected: number,
+  timeout = 10_000,
+) {
+  await expect
+    .poll(
+      async () => {
+        const docs = await fetchPlayerDocs(readerPage, gameId);
+        return docs.find((d) => d.user_id === userId)?.life_total;
+      },
+      { timeout, message: `server life_total for ${userId} never reached ${expected}` },
+    )
+    .toBe(expected);
 }

--- a/Treachery/e2e/host-promotion.spec.ts
+++ b/Treachery/e2e/host-promotion.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { fetchGameDoc, fetchPlayerDocs, setupLobby } from './helpers';
+
+/**
+ * Host promotion: what happens to a lobby when the host walks away.
+ *
+ * `leaveGame` promotes the next player by order_id rather than disbanding
+ * (functions/index.js → action: "promoted"), so the remaining players should
+ * be able to carry on and start the game. The server half works; the lobby
+ * screen's half does not.
+ */
+
+test.describe('Host leaves a lobby with players still in it', () => {
+  test('the server promotes the next player and the lobby shows the new host', async ({
+    browser,
+  }) => {
+    const { pages, userIds, gameId } = await setupLobby(browser, 3);
+    const [hostPage, secondPage, thirdPage] = pages;
+
+    expect((await fetchGameDoc(hostPage, gameId))?.host_id).toBe(userIds[0]);
+
+    // Host leaves (window.confirm on web).
+    hostPage.once('dialog', (d) => d.accept());
+    await hostPage.getByRole('button', { name: 'Leave game' }).click();
+
+    // The game survives, and host_id moves to the next seat.
+    await expect
+      .poll(async () => (await fetchGameDoc(secondPage, gameId))?.host_id, { timeout: 15_000 })
+      .toBe(userIds[1]);
+    expect((await fetchGameDoc(secondPage, gameId))?.state).toBe('waiting');
+
+    // The old host's player doc is gone; the other two remain.
+    const docs = await fetchPlayerDocs(secondPage, gameId);
+    expect(docs.map((d) => d.user_id).sort()).toEqual([userIds[1], userIds[2]].sort());
+
+    // Both remaining lobbies re-render with the Host badge on the new host.
+    // (The badge is derived from game.host_id, so this part already works.)
+    // `exact` matters: getByText is case-insensitive substring matching by
+    // default, which also picks up "Waiting for host to start the game...".
+    for (const page of [secondPage, thirdPage]) {
+      await expect(page.getByText('Players (2)')).toBeVisible();
+      await expect(page.getByText('Host', { exact: true })).toHaveCount(1);
+    }
+  });
+
+  // FIXME: currently broken — see finding #3. Un-fixme when the bug is fixed.
+  // The lobby screen freezes `isHost` from the `isHost` navigation param it was
+  // opened with (`const isHost = isHostParam === 'true'`), so a player promoted
+  // by the server still renders the guest view: no Start Game button, and
+  // useLobby.startGame bails out on `if (!isHost) return`. The promoted host
+  // has to leave and rejoin to unstick the lobby. isHost should be derived from
+  // game.host_id === currentUserId.
+  test.fixme('the promoted host can start the game', async ({ browser }) => {
+    const { pages, userIds, gameId } = await setupLobby(browser, 3);
+    const [hostPage, secondPage, thirdPage] = pages;
+
+    hostPage.once('dialog', (d) => d.accept());
+    await hostPage.getByRole('button', { name: 'Leave game' }).click();
+
+    await expect
+      .poll(async () => (await fetchGameDoc(secondPage, gameId))?.host_id, { timeout: 15_000 })
+      .toBe(userIds[1]);
+
+    // The promoted player now owns the lobby: settings and Start Game.
+    await expect(secondPage.getByText('GAME SETTINGS')).toBeVisible();
+    const start = secondPage.getByRole('button', { name: 'Start game' });
+    await expect(start).toBeEnabled({ timeout: 15_000 });
+    await start.click();
+
+    await Promise.all(
+      [secondPage, thirdPage].map((p) => expect(p).toHaveURL(/\/game\//, { timeout: 20_000 })),
+    );
+    expect((await fetchGameDoc(secondPage, gameId))?.state).toBe('in_progress');
+  });
+});

--- a/Treachery/e2e/non-treachery-modes.spec.ts
+++ b/Treachery/e2e/non-treachery-modes.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import {
+  GameMode,
+  damage,
+  expectServerLife,
+  fetchGameDoc,
+  fetchPlayerDocs,
+  setupNonTreacheryGame,
+} from './helpers';
+
+/**
+ * Non-treachery game modes: Life Tracker ('none') and Planechase.
+ *
+ * These modes have no roles, no identity cards, and no automatic win
+ * conditions — the host ends the game explicitly with End Game. Dropping a
+ * player to 0 life should therefore knock that one player out and leave
+ * everyone else playing.
+ *
+ * The whole suite was treachery-only before this file, so every one of these
+ * paths (startGame's non-treachery branch, the roleless game board, the
+ * non-treachery game-over summary) was completely uncovered.
+ *
+ * A low starting life keeps this quick: eliminating a player costs one `-1`
+ * click per point of life.
+ */
+
+const STARTING_LIFE = 20;
+
+const MODES: { mode: Exclude<GameMode, 'treachery' | 'treachery_planechase'>; label: string }[] = [
+  { mode: 'none', label: 'Life Tracker' },
+  { mode: 'planechase', label: 'Planechase' },
+];
+
+for (const { mode, label } of MODES) {
+  test.describe(`${label} mode`, () => {
+    test('starts with no roles or identity cards assigned', async ({ browser }) => {
+      const { gameId, players } = await setupNonTreacheryGame(browser, 4, mode, {
+        startingLife: STARTING_LIFE,
+      });
+
+      const game = await fetchGameDoc(players[0].page, gameId);
+      expect(game?.game_mode).toBe(mode);
+      expect(game?.state).toBe('in_progress');
+
+      const docs = await fetchPlayerDocs(players[0].page, gameId);
+      expect(docs).toHaveLength(4);
+      for (const doc of docs) {
+        expect(doc.role).toBeNull();
+        expect(doc.identity_card_id).toBeNull();
+        expect(doc.life_total).toBe(STARTING_LIFE);
+      }
+
+      // No treachery affordances on the board: nothing to unveil or forfeit.
+      await expect(players[1].page.getByRole('button', { name: 'Unveil identity' })).toHaveCount(0);
+      await expect(players[1].page.getByRole('button', { name: 'Forfeit' })).toHaveCount(0);
+    });
+
+    // FIXME: currently broken — see finding #1. Un-fixme when the bug is fixed.
+    // adjustLife runs checkWinConditions for every mode. With no roles at all,
+    // checkWinConditions falls through to `!leaderAlive && !assassinAlive &&
+    // !traitorAlive → "assassin"`, so the first player to reach 0 life ends the
+    // game for the whole table. The win check must be gated on the game mode
+    // including treachery.
+    test.fixme(
+      'a player hitting 0 life does not end the game for everyone else',
+      async ({ browser }) => {
+        const { gameId, players } = await setupNonTreacheryGame(browser, 4, mode, {
+          startingLife: STARTING_LIFE,
+        });
+        const [p1, p2, p3, p4] = players;
+
+        // p1 knocks p2 out.
+        await damage(p1.page, p2.name, STARTING_LIFE);
+        await expectServerLife(p1.page, gameId, p2.userId, 0);
+
+        await expect
+          .poll(async () => (await fetchPlayerDocs(p1.page, gameId)).find((d) => d.user_id === p2.userId)?.is_eliminated)
+          .toBe(true);
+
+        // The game must still be running, with no winner declared.
+        const game = await fetchGameDoc(p1.page, gameId);
+        expect(game?.state).toBe('in_progress');
+        expect(game?.winning_team ?? null).toBeNull();
+
+        // Nobody got bounced to the game-over screen.
+        for (const p of players) {
+          await expect(p.page).toHaveURL(/\/game\//);
+        }
+
+        // And the survivors keep playing.
+        await damage(p3.page, p4.name, 3);
+        await expectServerLife(p3.page, gameId, p4.userId, STARTING_LIFE - 3);
+        expect((await fetchGameDoc(p1.page, gameId))?.state).toBe('in_progress');
+      },
+    );
+
+    test('the host can end the game explicitly', async ({ browser }) => {
+      const { gameId, players, host } = await setupNonTreacheryGame(browser, 4, mode, {
+        startingLife: STARTING_LIFE,
+      });
+
+      // End Game is host-only in non-treachery modes.
+      await expect(players[1].page.getByRole('button', { name: 'End game' })).toHaveCount(0);
+
+      await host.page.getByRole('button', { name: 'End game' }).click();
+      // Winner selection modal — skip picking anyone and just end it.
+      await host.page
+        .getByRole('button', { name: 'End game' })
+        .last()
+        .click();
+
+      await Promise.all(
+        players.map((p) => expect(p.page).toHaveURL(/\/game-over\//, { timeout: 20_000 })),
+      );
+      expect((await fetchGameDoc(host.page, gameId))?.state).toBe('finished');
+
+      // The non-treachery game-over screen is a life-total summary — it must
+      // not pretend there were teams.
+      await expect(host.page.getByText(/Session ended with 4 players/)).toBeVisible();
+    });
+  });
+}

--- a/Treachery/e2e/simulation.spec.ts
+++ b/Treachery/e2e/simulation.spec.ts
@@ -1,0 +1,123 @@
+import { test } from '@playwright/test';
+import { GameMode } from './helpers';
+import { KNOWN_BROKEN_INVARIANTS } from './simulation/invariants';
+import { SimConfig, runSimulation } from './simulation/runner';
+import { resolveSeed } from './simulation/rng';
+
+/**
+ * Randomised multi-player simulation ("fuzz") harness.
+ *
+ * Unlike the hand-written specs, nothing here scripts a scenario. Each test
+ * spins up a real multi-context game and then repeatedly picks a legal move at
+ * random — damage, heal, unveil (including the traitor ability resolvers),
+ * forfeit — and asserts EVERY invariant in simulation/invariants.ts after each
+ * one. The point is to reach states no one thought to write a test for.
+ *
+ * ── Reproducing a failure ──────────────────────────────────────────────
+ * The failure message prints the seed and the exact move list. Replay with:
+ *
+ *   SIM_SEED=<seed> npm run test:e2e -- simulation
+ *
+ * ── Fuzzing harder locally ─────────────────────────────────────────────
+ * CI runs a small, pinned set so it stays deterministic and fast. To actually
+ * hunt for bugs, crank it up:
+ *
+ *   SIM_SEED=random SIM_STEPS=60 SIM_REPEAT=25 npm run test:e2e -- simulation
+ *
+ *   SIM_SEED    integer, or "random" to re-roll each run (default: BASE_SEED)
+ *   SIM_STEPS   max actions per game            (default: 14)
+ *   SIM_REPEAT  how many times to run the set   (default: 1)
+ *   SIM_LIFE    starting life                   (default: 20 — fewer clicks)
+ *
+ * ── Known-broken invariants ────────────────────────────────────────────
+ * Some invariants describe behaviour the app gets wrong today. Those are
+ * listed in KNOWN_BROKEN_INVARIANTS and skipped so CI stays green; flip the
+ * flag to `false` once the fix lands. See simulation/invariants.ts.
+ */
+
+// Pinned so a CI run is reproducible build to build. This particular value was
+// chosen because its derived streams resolve a Puppet Master redistribution in
+// game 1 and open the Metamorph resolver in game 2, so even the short CI run
+// covers the ability paths rather than only life arithmetic.
+const BASE_SEED = 31337;
+
+const SEED = resolveSeed(BASE_SEED);
+const MAX_STEPS = Number.parseInt(process.env.SIM_STEPS ?? '14', 10);
+const REPEAT = Number.parseInt(process.env.SIM_REPEAT ?? '1', 10);
+const STARTING_LIFE = Number.parseInt(process.env.SIM_LIFE ?? '20', 10);
+
+/**
+ * The default set: two treachery games at different player counts plus one
+ * Life Tracker game, which is the only simulation coverage the non-treachery
+ * code path has. Each game gets its own derived seed so adding or removing a
+ * game doesn't reshuffle the others.
+ */
+const GAMES: { label: string; playerCount: number; mode: GameMode }[] = [
+  { label: '4-player treachery', playerCount: 4, mode: 'treachery' },
+  { label: '5-player treachery', playerCount: 5, mode: 'treachery' },
+  { label: '4-player life tracker', playerCount: 4, mode: 'none' },
+];
+
+function derivedSeed(base: number, index: number): number {
+  // Cheap decorrelation so game N's stream doesn't shadow game N-1's.
+  return (base ^ Math.imul(index + 1, 0x9e3779b9)) >>> 0;
+}
+
+test.describe('Simulation', () => {
+  // Each step is a real UI action plus a server round trip, so a long run
+  // needs more than the 60s default.
+  test.setTimeout(Math.max(180_000, MAX_STEPS * 12_000));
+
+  for (let repeat = 0; repeat < REPEAT; repeat++) {
+    GAMES.forEach((game, index) => {
+      const seed = derivedSeed(SEED, repeat * GAMES.length + index);
+      const suffix = REPEAT > 1 ? ` #${repeat + 1}` : '';
+
+      // The seed deliberately stays OUT of the title: with SIM_SEED=random it
+      // would differ between the collecting process and the worker, and
+      // Playwright matches tests by title. It is printed instead — in the run
+      // log on success and in the failure message on error.
+      test(`${game.label} plays out without breaking an invariant${suffix}`, async ({
+        browser,
+      }) => {
+        const config: SimConfig = {
+          label: `${game.label}${suffix}`,
+          playerCount: game.playerCount,
+          mode: game.mode,
+          maxSteps: MAX_STEPS,
+          startingLife: STARTING_LIFE,
+          seed,
+          // Replay knobs, not the derived per-game stream — SIM_SEED is the
+          // base the per-game seeds are derived from, so only these values
+          // together reproduce this exact game.
+          repro: {
+            SIM_SEED: SEED,
+            SIM_STEPS: MAX_STEPS,
+            SIM_REPEAT: REPEAT,
+            SIM_LIFE: STARTING_LIFE,
+          },
+        };
+
+        const result = await runSimulation(browser, config);
+        // Printed on success too — a passing run's move list is the cheapest
+        // way to see what the fuzzer actually explored.
+        console.log(result.log.join('\n'));
+      });
+    });
+  }
+});
+
+test('the known-broken invariant list is honest about what is disabled', () => {
+  // A guard rail, not a behaviour test: if someone flips one of these to
+  // `false` without the fix, the simulation starts failing and the reason is
+  // right here. If someone fixes a bug, this list is where they turn the
+  // check back on.
+  const disabled = Object.entries(KNOWN_BROKEN_INVARIANTS)
+    .filter(([, isBroken]) => isBroken)
+    .map(([name]) => name);
+  console.log(
+    disabled.length === 0
+      ? 'All simulation invariants are enforced.'
+      : `Simulation invariants currently disabled (known bugs): ${disabled.join(', ')}`,
+  );
+});

--- a/Treachery/e2e/simulation/cards.ts
+++ b/Treachery/e2e/simulation/cards.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import { Role } from '../helpers';
+
+/**
+ * Identity card metadata, read straight off the copy the Cloud Functions use.
+ *
+ * The invariants need to know a card's role (to assert `player.role` still
+ * matches the card it holds) and its life modifier (to predict starting life).
+ * Reading functions/identityCards.json rather than re-declaring the data here
+ * means the harness can never drift from the server's view of the deck.
+ */
+
+export interface CardMeta {
+  id: string;
+  name: string;
+  role: Role;
+  rarity: string;
+  life_modifier: number | null;
+}
+
+const CARDS_PATH = path.resolve(__dirname, '../../../functions/identityCards.json');
+
+export const ALL_CARDS: CardMeta[] = JSON.parse(fs.readFileSync(CARDS_PATH, 'utf8'));
+
+const BY_ID = new Map(ALL_CARDS.map((c) => [c.id, c]));
+
+export function card(id: string): CardMeta {
+  const found = BY_ID.get(id);
+  if (!found) throw new Error(`Unknown identity card id: ${id}`);
+  return found;
+}
+
+export function cardOrNull(id: string | null | undefined): CardMeta | null {
+  if (!id) return null;
+  return BY_ID.get(id) ?? null;
+}
+
+/** Life a player starts with, given the game's starting_life and their card. */
+export function startingLifeFor(gameStartingLife: number, cardId: string | null): number {
+  return gameStartingLife + (cardOrNull(cardId)?.life_modifier ?? 0);
+}
+
+// The three traitor identities with a follow-up resolver modal. The simulation
+// deliberately seeds these so the fuzzer walks the ability code paths that the
+// hand-written abilities.spec.ts only visits one at a time.
+export const METAMORPH = 'traitor_07';
+export const PUPPET_MASTER = 'traitor_09';
+export const WEARER_OF_MASKS = 'traitor_13';
+export const ABILITY_TRAITOR_CARDS = [METAMORPH, PUPPET_MASTER, WEARER_OF_MASKS] as const;

--- a/Treachery/e2e/simulation/invariants.ts
+++ b/Treachery/e2e/simulation/invariants.ts
@@ -1,0 +1,257 @@
+import { GameMode, Role, ServerGame, ServerPlayer } from '../helpers';
+import { cardOrNull, WEARER_OF_MASKS } from './cards';
+
+/**
+ * Invariants the server state must satisfy after *every* action the fuzzer
+ * takes. These are the point of the whole harness: any legal sequence of moves
+ * that breaks one of these is a state-machine bug, whether or not a
+ * hand-written scenario would ever have produced that sequence.
+ *
+ * Each check is a pure function of (previous snapshot, current snapshot,
+ * expectations tracked by the runner) so it can be unit-reasoned about and so
+ * failures name themselves.
+ */
+
+// ════════════════════════════════════════════════════════════════
+// KNOWN-BROKEN INVARIANTS
+//
+// `true` = the app violates this today, so the harness SKIPS the check and
+// stays green in CI. Flip the entry to `false` after the corresponding fix
+// lands and the harness starts enforcing it again. Do not delete entries —
+// the comment is the record of what is wrong and where.
+// ════════════════════════════════════════════════════════════════
+
+export const KNOWN_BROKEN_INVARIANTS = {
+  /**
+   * FIXME: currently broken — see finding #1. Flip to `false` when the bug is fixed.
+   *
+   * adjustLife/eliminatePlayer run checkWinConditions for EVERY game mode.
+   * In planechase / 'none' (Life Tracker) games nobody has a role, so
+   * checkWinConditions hits its `!leaderAlive && !assassinAlive &&
+   * !traitorAlive` branch and returns "assassin" — the first player to hit 0
+   * life instantly ends the game for everyone. The win check needs to be
+   * gated on the game mode including treachery.
+   */
+  nonTreacheryGameNeverAutoFinishes: true,
+
+  /**
+   * FIXME: currently broken — see finding #5. Flip to `false` when the bug is fixed.
+   *
+   * resolveMetamorph moves the eliminated target's identity_card_id onto the
+   * caller but never clears it from the target, so after a steal two player
+   * docs hold the same card. The game-over screen then renders the same
+   * identity twice, and any future Metamorph/Wearer-of-Masks "is this card
+   * already in the game" check sees a phantom copy.
+   */
+  identityCardsAreUnique: true,
+} as const;
+
+// ════════════════════════════════════════════════════════════════
+
+export interface Snapshot {
+  game: ServerGame;
+  players: ServerPlayer[];
+}
+
+/** What the runner believes should be true, accumulated as it plays. */
+export interface Expectations {
+  mode: GameMode;
+  /** user_id → life total implied by the deltas we actually applied. */
+  life: Map<string, number>;
+  /** user_ids we have seen eliminated (elimination is one-way). */
+  eliminated: Set<string>;
+  /** user_ids we have seen unveiled (unveiling is one-way). */
+  unveiled: Set<string>;
+}
+
+const STATE_ORDER = { waiting: 0, in_progress: 1, finished: 2 } as const;
+
+export class InvariantViolation extends Error {
+  constructor(
+    readonly invariant: string,
+    message: string,
+  ) {
+    super(`[${invariant}] ${message}`);
+    this.name = 'InvariantViolation';
+  }
+}
+
+function fail(invariant: string, message: string): never {
+  throw new InvariantViolation(invariant, message);
+}
+
+function label(p: ServerPlayer): string {
+  return `${p.display_name ?? p.user_id}(${p.id})`;
+}
+
+/**
+ * Mirror of checkWinConditions in functions/index.js. Kept as a duplicate on
+ * purpose: if the server's rules change without this changing, the
+ * winner-consistency invariant fires and someone has to reconcile the two.
+ */
+export function expectedWinner(players: ServerPlayer[]): Role | null {
+  const alive = players.filter((p) => !p.is_eliminated);
+  if (alive.length === 1 && alive[0].role === 'traitor') return 'traitor';
+
+  const leaderAlive = alive.some((p) => p.role === 'leader');
+  const assassinAlive = alive.some((p) => p.role === 'assassin');
+  const traitorAlive = alive.some((p) => p.role === 'traitor');
+
+  if (!leaderAlive && assassinAlive) return 'assassin';
+  if (leaderAlive && !assassinAlive && !traitorAlive) return 'leader';
+  if (!leaderAlive && !assassinAlive && !traitorAlive) return 'assassin';
+  return null;
+}
+
+function isTreachery(mode: GameMode): boolean {
+  return mode === 'treachery' || mode === 'treachery_planechase';
+}
+
+/**
+ * Run every invariant against a fresh snapshot.
+ *
+ * @param previous the snapshot from before the action (null on the first check)
+ * @param current  the snapshot read back after the action settled
+ * @param expect   the runner's running model of what should have happened
+ * @param lastActionWasLifeChange whether the action just taken was a +/- tap;
+ *        used by the non-treachery "a life change must not end the game" rule
+ */
+export function checkInvariants(
+  previous: Snapshot | null,
+  current: Snapshot,
+  expect: Expectations,
+  lastActionWasLifeChange: boolean,
+): void {
+  const { game, players } = current;
+  const treachery = isTreachery(expect.mode);
+
+  // ── 1. State machine only moves forward ────────────────────────
+  const state = game.state ?? 'waiting';
+  if (!(state in STATE_ORDER)) fail('stateIsKnown', `unexpected game state ${JSON.stringify(state)}`);
+  if (previous) {
+    const before = previous.game.state ?? 'waiting';
+    if (STATE_ORDER[state] < STATE_ORDER[before]) {
+      fail('stateMonotonic', `game state went backwards: ${before} → ${state}`);
+    }
+  }
+
+  // ── 2. The roster is fixed once the game is running ────────────
+  if (previous && previous.players.length !== players.length) {
+    fail(
+      'rosterStable',
+      `player count changed mid-game: ${previous.players.length} → ${players.length}`,
+    );
+  }
+
+  for (const p of players) {
+    const life = p.life_total ?? 0;
+
+    // ── 3. Life is never negative ────────────────────────────────
+    if (life < 0) fail('lifeNeverNegative', `${label(p)} has life_total ${life}`);
+
+    // ── 4. 0 life means eliminated ───────────────────────────────
+    if (life === 0 && !p.is_eliminated) {
+      fail('zeroLifeIsEliminated', `${label(p)} is at 0 life but is_eliminated is ${p.is_eliminated}`);
+    }
+
+    // ── 5. Eliminated players are always face up ─────────────────
+    if (p.is_eliminated && !p.is_unveiled) {
+      fail('eliminatedIsUnveiled', `${label(p)} is eliminated but is_unveiled is ${p.is_unveiled}`);
+    }
+
+    // ── 6. Elimination and unveiling are one-way ─────────────────
+    if (expect.eliminated.has(p.user_id) && !p.is_eliminated) {
+      fail('eliminationIsPermanent', `${label(p)} was eliminated earlier but is alive again`);
+    }
+    if (expect.unveiled.has(p.user_id) && !p.is_unveiled) {
+      fail('unveilIsPermanent', `${label(p)} was unveiled earlier but is concealed again`);
+    }
+
+    if (treachery) {
+      // ── 7. Exactly one identity card per player ────────────────
+      if (!p.identity_card_id) {
+        fail('oneCardPerPlayer', `${label(p)} holds no identity card in a treachery game`);
+      }
+      const held = cardOrNull(p.identity_card_id);
+      if (!held) {
+        fail('cardExists', `${label(p)} holds unknown card ${p.identity_card_id}`);
+      }
+
+      // ── 8. Role follows the card ───────────────────────────────
+      // Metamorph and Puppet Master transfer the identity itself, so role
+      // moves with the card. The Wearer of Masks is the documented exception:
+      // it copies a non-Leader card but the player stays a Traitor.
+      const isWearerOfMasks =
+        p.original_identity_card_id === WEARER_OF_MASKS || p.identity_card_id === WEARER_OF_MASKS;
+      if (!isWearerOfMasks && p.role !== held.role) {
+        fail(
+          'roleMatchesCard',
+          `${label(p)} has role ${p.role} but holds ${held.id} (${held.role})`,
+        );
+      }
+      if (isWearerOfMasks && p.role !== 'traitor') {
+        fail(
+          'wearerOfMasksStaysTraitor',
+          `${label(p)} copied ${p.identity_card_id} via the Wearer of Masks but role is ${p.role}`,
+        );
+      }
+    } else {
+      // Non-treachery modes assign no roles or cards at all.
+      if (p.role !== null || p.identity_card_id !== null) {
+        fail(
+          'noRolesOutsideTreachery',
+          `${label(p)} has role=${p.role} card=${p.identity_card_id} in a ${expect.mode} game`,
+        );
+      }
+    }
+
+    // ── 9. Life arithmetic — every delta we applied, and nothing else ──
+    const predicted = expect.life.get(p.user_id);
+    if (predicted !== undefined && predicted !== life) {
+      fail(
+        'lifeArithmetic',
+        `${label(p)} should be at ${predicted} life after the deltas we applied, server says ${life}` +
+          ' (a dropped or duplicated adjustLife call)',
+      );
+    }
+  }
+
+  // ── 10. No two players hold the same identity card ─────────────
+  if (treachery && !KNOWN_BROKEN_INVARIANTS.identityCardsAreUnique) {
+    const seen = new Map<string, ServerPlayer>();
+    for (const p of players) {
+      if (!p.identity_card_id) continue;
+      const other = seen.get(p.identity_card_id);
+      if (other) {
+        fail(
+          'identityCardsAreUnique',
+          `${label(p)} and ${label(other)} both hold ${p.identity_card_id}`,
+        );
+      }
+      seen.set(p.identity_card_id, p);
+    }
+  }
+
+  // ── 11. A life change must never end a non-treachery game ──────
+  if (!treachery && lastActionWasLifeChange && !KNOWN_BROKEN_INVARIANTS.nonTreacheryGameNeverAutoFinishes) {
+    if (state === 'finished') {
+      fail(
+        'nonTreacheryGameNeverAutoFinishes',
+        `a life change ended a ${expect.mode} game (winning_team=${game.winning_team})` +
+          ' — only the host pressing End Game may finish these modes',
+      );
+    }
+  }
+
+  // ── 12. The declared winner matches the final roles ────────────
+  if (state === 'finished' && treachery && game.winning_team) {
+    const derived = expectedWinner(players);
+    if (derived !== game.winning_team) {
+      fail(
+        'winnerMatchesRoles',
+        `game declared winning_team=${game.winning_team} but the final roles imply ${derived}` +
+          ` (${players.map((p) => `${label(p)}:${p.role}${p.is_eliminated ? '☠' : ''}`).join(', ')})`,
+      );
+    }
+  }
+}

--- a/Treachery/e2e/simulation/rng.ts
+++ b/Treachery/e2e/simulation/rng.ts
@@ -1,0 +1,88 @@
+/**
+ * Deterministic RNG for the fuzz harness.
+ *
+ * Every random choice the simulation makes — which player acts, what they do,
+ * how hard they hit — comes from here, so a failing run is reproducible from
+ * its seed alone (`SIM_SEED=... npm run test:e2e`). Math.random() must never
+ * be used inside e2e/simulation for that reason.
+ */
+
+/** mulberry32 — small, fast, good enough for choosing moves. */
+export class Rng {
+  private state: number;
+
+  constructor(readonly seed: number) {
+    // Force to uint32 so the same seed produces the same stream everywhere.
+    this.state = seed >>> 0;
+  }
+
+  /** Uniform float in [0, 1). */
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0;
+    let t = this.state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /** Uniform integer in [min, max] inclusive. */
+  int(min: number, max: number): number {
+    if (max < min) throw new Error(`Rng.int: max (${max}) < min (${min})`);
+    return min + Math.floor(this.next() * (max - min + 1));
+  }
+
+  /** True with probability `p`. */
+  chance(p: number): boolean {
+    return this.next() < p;
+  }
+
+  /** Uniform element of a non-empty array. */
+  pick<T>(items: readonly T[]): T {
+    if (items.length === 0) throw new Error('Rng.pick: empty array');
+    return items[this.int(0, items.length - 1)];
+  }
+
+  /** Weighted pick. Entries with weight <= 0 are never chosen. */
+  pickWeighted<T>(entries: readonly { value: T; weight: number }[]): T {
+    const usable = entries.filter((e) => e.weight > 0);
+    if (usable.length === 0) throw new Error('Rng.pickWeighted: no entry with positive weight');
+    const total = usable.reduce((sum, e) => sum + e.weight, 0);
+    let roll = this.next() * total;
+    for (const entry of usable) {
+      roll -= entry.weight;
+      if (roll <= 0) return entry.value;
+    }
+    return usable[usable.length - 1].value;
+  }
+
+  /** Fisher-Yates copy, driven by this stream. */
+  shuffled<T>(items: readonly T[]): T[] {
+    const arr = [...items];
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = this.int(0, i);
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+}
+
+/**
+ * Resolve the run's seed. CI pins a constant so the suite is reproducible
+ * build to build; locally, `SIM_SEED=random` (or any integer) re-rolls it.
+ */
+export function resolveSeed(fallback: number): number {
+  const raw = process.env.SIM_SEED;
+  if (!raw) return fallback;
+  if (raw === 'random') {
+    const rolled = Math.floor(Math.random() * 0xffffffff);
+    // Pin it back into the environment so worker processes, which re-import
+    // this file, roll the *same* seed as the process that collected the tests.
+    process.env.SIM_SEED = String(rolled);
+    return rolled;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`SIM_SEED must be an integer or "random" (got ${JSON.stringify(raw)})`);
+  }
+  return parsed >>> 0;
+}

--- a/Treachery/e2e/simulation/runner.ts
+++ b/Treachery/e2e/simulation/runner.ts
@@ -1,0 +1,509 @@
+import { Browser, Page, expect } from '@playwright/test';
+import {
+  GameMode,
+  PlayerHandle,
+  ROLE_DISTRIBUTION,
+  Role,
+  SeededGame,
+  ServerPlayer,
+  damage,
+  fetchGameDoc,
+  fetchPlayerDocs,
+  forfeit,
+  heal,
+  setupNonTreacheryGame,
+  setupSeededGame,
+  unveilSelf,
+} from '../helpers';
+import { Rng } from './rng';
+import { ABILITY_TRAITOR_CARDS, startingLifeFor } from './cards';
+import {
+  Expectations,
+  InvariantViolation,
+  Snapshot,
+  checkInvariants,
+} from './invariants';
+
+/**
+ * The fuzz loop.
+ *
+ * Each step: read the true server state, enumerate the moves that are legal
+ * *right now*, pick one with the seeded RNG, drive it through the real UI,
+ * wait for the server to settle, then re-read and assert every invariant.
+ *
+ * Everything random comes from {@link Rng}, so a failing run replays exactly
+ * from its printed seed.
+ */
+
+export interface SimConfig {
+  /** Shown in test titles and failure output. */
+  label: string;
+  playerCount: number;
+  mode: GameMode;
+  /** Upper bound on actions; the run also stops early when the game finishes. */
+  maxSteps: number;
+  /** Lower starting life ⇒ fewer clicks per elimination ⇒ faster runs. */
+  startingLife: number;
+  /** This game's RNG stream, derived from `repro.SIM_SEED`. */
+  seed: number;
+  /**
+   * The exact environment that produced this run. Printed verbatim on failure:
+   * the per-game `seed` above is *derived*, so feeding it back in as SIM_SEED
+   * would replay a different game.
+   */
+  repro: Record<string, string | number>;
+}
+
+export interface SimResult {
+  steps: number;
+  finished: boolean;
+  winningTeam: string | null;
+  log: string[];
+}
+
+type ActionKind = 'damage' | 'heal' | 'unveil' | 'forfeit' | 'ability';
+
+interface Candidate {
+  kind: ActionKind;
+  actor: PlayerHandle;
+  target?: PlayerHandle;
+  amount?: number;
+}
+
+/**
+ * Weights are per *kind*, not per candidate — the kind is drawn first and then
+ * a candidate of that kind uniformly. Weighting the flat candidate list would
+ * bury unveils: an N-player game offers N² damage candidates against at most
+ * N unveils, so unveils (and therefore the whole ability-resolver code path)
+ * would almost never be chosen.
+ *
+ * Damage dominates so games actually progress toward eliminations; forfeit is
+ * rare because one forfeit can end a 4-player game outright.
+ */
+const WEIGHTS: Record<ActionKind, number> = {
+  damage: 50,
+  heal: 18,
+  unveil: 18,
+  ability: 9,
+  forfeit: 5,
+};
+
+/** Host = seat 0. Roles are laid out leader → guardians → assassins → traitors. */
+function buildLayout(count: number): Role[] {
+  const dist = ROLE_DISTRIBUTION[count];
+  if (!dist) throw new Error(`No role distribution for ${count} players`);
+  const layout: Role[] = [];
+  for (let i = 0; i < dist.leader; i++) layout.push('leader');
+  for (let i = 0; i < dist.guardian; i++) layout.push('guardian');
+  for (let i = 0; i < dist.assassin; i++) layout.push('assassin');
+  for (let i = 0; i < dist.traitor; i++) layout.push('traitor');
+  return layout;
+}
+
+/**
+ * Give the traitor(s) a randomly chosen *ability* card so the fuzzer actually
+ * walks the Metamorph / Puppet Master / Wearer of Masks resolvers instead of
+ * always drawing the first traitor in the deck.
+ */
+function pickCardOverrides(rng: Rng, layout: Role[]): Record<number, string> {
+  const overrides: Record<number, string> = {};
+  const pool = rng.shuffled(ABILITY_TRAITOR_CARDS);
+  let next = 0;
+  layout.forEach((role, index) => {
+    if (role !== 'traitor') return;
+    if (next < pool.length && rng.chance(0.8)) {
+      overrides[index] = pool[next++];
+    }
+  });
+  return overrides;
+}
+
+/**
+ * Read a *consistent* snapshot of the game doc and its players.
+ *
+ * The elimination transaction writes `players/{id}.life_total` and
+ * `games/{id}.state` together, but we read them with two separate queries, so
+ * a naive read can straddle the commit and produce a game that is still
+ * "in_progress" alongside players that say otherwise. Bracketing the player
+ * read with two game reads and requiring the state to match rules that out.
+ */
+async function readSnapshot(readerPage: Page, gameId: string): Promise<Snapshot> {
+  // Reads also occasionally land mid client-side navigation (a forfeiting page
+  // is swapping to /game-over); the same retry loop rides that out.
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const before = await fetchGameDoc(readerPage, gameId);
+      const players = await fetchPlayerDocs(readerPage, gameId);
+      const after = await fetchGameDoc(readerPage, gameId);
+      if (!before || !after) throw new Error(`Game ${gameId} disappeared`);
+      if (before.state === after.state) return { game: after, players };
+      // A transition committed while we were reading — take a fresh sample.
+    } catch (error) {
+      if (attempt >= 3) throw error;
+      await readerPage.waitForTimeout(400);
+    }
+    if (attempt >= 3) throw new Error(`Game ${gameId} state kept changing mid-read`);
+  }
+}
+
+function serverPlayerFor(snapshot: Snapshot, handle: PlayerHandle): ServerPlayer {
+  const found = snapshot.players.find((p) => p.user_id === handle.userId);
+  if (!found) throw new Error(`No player doc for ${handle.name} (${handle.userId})`);
+  return found;
+}
+
+/** Poll until `predicate` holds on a fresh snapshot, or the deadline passes. */
+async function settle(
+  readerPage: Page,
+  gameId: string,
+  predicate: (s: Snapshot) => boolean,
+  timeoutMs = 10_000,
+): Promise<Snapshot> {
+  const deadline = Date.now() + timeoutMs;
+  let snapshot = await readSnapshot(readerPage, gameId);
+  while (!predicate(snapshot) && Date.now() < deadline) {
+    await readerPage.waitForTimeout(250);
+    snapshot = await readSnapshot(readerPage, gameId);
+  }
+  // Deliberately no throw on timeout: an update that never lands is exactly
+  // what the lifeArithmetic invariant exists to report, with better context.
+  return snapshot;
+}
+
+/** True once the server says the game is over. */
+async function isFinished(readerPage: Page, gameId: string): Promise<boolean> {
+  try {
+    return (await fetchGameDoc(readerPage, gameId))?.state === 'finished';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve (or decline) whichever traitor ability modal auto-opened after an
+ * unveil. Leaving it open would block every later click on that page, so this
+ * always leaves the board clickable again.
+ */
+async function handleAbilityModal(page: Page, cardId: string, rng: Rng, log: string[]) {
+  const decline = page.getByRole('button', { name: 'Decline ability' });
+  const skip = page.getByRole('button', { name: 'Skip ability' });
+
+  if (cardId === 'traitor_07') {
+    await expect(decline).toBeVisible({ timeout: 10_000 });
+    const steal = page.getByRole('button', { name: /^Steal from / });
+    const count = await steal.count();
+    if (count > 0 && rng.chance(0.75)) {
+      await steal.nth(rng.int(0, count - 1)).click();
+      await page.getByRole('button', { name: 'Steal identity' }).click();
+      log.push('    ability: Metamorph stole an eliminated identity');
+    } else {
+      await decline.click();
+      log.push('    ability: Metamorph declined');
+    }
+  } else if (cardId === 'traitor_09') {
+    await expect(decline).toBeVisible({ timeout: 10_000 });
+    const swap = page.getByRole('button', { name: /^Swap with / });
+    const count = await swap.count();
+    if (count >= 2 && rng.chance(0.75)) {
+      const [a, b] = rng.shuffled([...Array(count).keys()]).slice(0, 2);
+      await swap.nth(a).click();
+      await swap.nth(b).click();
+      await page.getByRole('button', { name: 'Confirm redistribution' }).click();
+      log.push('    ability: Puppet Master swapped two identities');
+    } else {
+      await decline.click();
+      log.push('    ability: Puppet Master declined');
+    }
+  } else if (cardId === 'traitor_13') {
+    await expect(skip).toBeVisible({ timeout: 10_000 });
+    if (rng.chance(0.75)) {
+      await page.getByRole('button', { name: 'Reveal cards' }).click();
+      const picks = page.getByRole('button', { name: /^Pick identity / });
+      await expect(picks.first()).toBeVisible({ timeout: 10_000 });
+      const count = await picks.count();
+      await picks.nth(rng.int(0, count - 1)).click();
+      await page.getByRole('button', { name: 'Become this identity' }).click();
+      log.push('    ability: Wearer of Masks copied a card');
+    } else {
+      await skip.click();
+      log.push('    ability: Wearer of Masks skipped');
+    }
+  }
+
+  // The sheet closes on resolve/decline; make sure nothing is left covering
+  // the board before the next step tries to click a life button.
+  await expect(decline.or(skip)).toBeHidden({ timeout: 10_000 });
+}
+
+/** Every move that is legal against the current server state, grouped by kind. */
+function legalMoves(
+  game: SeededGame,
+  snapshot: Snapshot,
+  rng: Rng,
+  treachery: boolean,
+): Map<ActionKind, Candidate[]> {
+  const alive = game.players.filter((h) => !serverPlayerFor(snapshot, h).is_eliminated);
+  const byKind = new Map<ActionKind, Candidate[]>();
+  const add = (c: Candidate) => {
+    const list = byKind.get(c.kind);
+    if (list) list.push(c);
+    else byKind.set(c.kind, [c]);
+  };
+
+  for (const actor of alive) {
+    const actorDoc = serverPlayerFor(snapshot, actor);
+
+    for (const target of alive) {
+      const life = serverPlayerFor(snapshot, target).life_total ?? 0;
+      if (life <= 0) continue;
+
+      // Sometimes swing for the kill; usually chip away without eliminating.
+      const lethal = rng.chance(0.15);
+      const amount = lethal || life === 1 ? life : Math.min(life - 1, rng.int(1, 3));
+      if (amount > 0) add({ kind: 'damage', actor, target, amount });
+      add({ kind: 'heal', actor, target, amount: rng.int(1, 3) });
+    }
+
+    if (treachery) {
+      const cardId = actorDoc.identity_card_id ?? '';
+      const hasResolver = (ABILITY_TRAITOR_CARDS as readonly string[]).includes(cardId);
+
+      // unveilPlayer rejects leaders (always visible) and anyone already unveiled.
+      if (!actorDoc.is_unveiled && actorDoc.role !== 'leader') {
+        add({ kind: 'unveil', actor });
+        // Importance sampling: unveiling one of the three resolver traitors is
+        // the only way into the Metamorph / Puppet Master / Wearer of Masks
+        // code paths, and a uniform pick reaches them roughly once per twenty
+        // unveils. Weighting them up keeps a short CI run meaningful without
+        // making any illegal move reachable.
+        if (hasResolver) {
+          add({ kind: 'unveil', actor });
+          add({ kind: 'unveil', actor });
+          add({ kind: 'unveil', actor });
+        }
+      }
+
+      // The resolver sheet auto-opens once at unveil, but the board keeps an
+      // "Activate Ability" button for as long as the player still holds the
+      // card. That re-entry matters: the Metamorph has nothing to steal until
+      // somebody has been eliminated, which is usually long after it unveiled.
+      if (actorDoc.is_unveiled && hasResolver) {
+        add({ kind: 'ability', actor });
+      }
+
+      add({ kind: 'forfeit', actor });
+    }
+  }
+
+  return byKind;
+}
+
+/** Draw a kind by weight, then a candidate of that kind uniformly. */
+function chooseMove(byKind: Map<ActionKind, Candidate[]>, rng: Rng): Candidate | null {
+  const kinds = [...byKind.entries()]
+    .filter(([, list]) => list.length > 0)
+    .map(([kind]) => ({ value: kind, weight: WEIGHTS[kind] }));
+  if (kinds.length === 0) return null;
+  return rng.pick(byKind.get(rng.pickWeighted(kinds))!);
+}
+
+export async function runSimulation(browser: Browser, config: SimConfig): Promise<SimResult> {
+  const rng = new Rng(config.seed);
+  const treachery = config.mode === 'treachery' || config.mode === 'treachery_planechase';
+  const log: string[] = [
+    `sim "${config.label}": seed=${config.seed} players=${config.playerCount} mode=${config.mode} startingLife=${config.startingLife}`,
+  ];
+
+  let game: SeededGame;
+  if (treachery) {
+    const layout = buildLayout(config.playerCount);
+    const cardOverrides = pickCardOverrides(rng, layout);
+    log.push(`  seeded roles: ${layout.join(', ')}; overrides: ${JSON.stringify(cardOverrides)}`);
+    game = await setupSeededGame(browser, layout, {
+      cardOverrides,
+      startingLife: config.startingLife,
+    });
+  } else {
+    game = await setupNonTreacheryGame(
+      browser,
+      config.playerCount,
+      config.mode as 'planechase' | 'none',
+      { startingLife: config.startingLife },
+    );
+  }
+
+  const readerPage = game.players[0].page;
+  const expectations: Expectations = {
+    mode: config.mode,
+    life: new Map(),
+    eliminated: new Set(),
+    unveiled: new Set(),
+  };
+
+  let snapshot = await readSnapshot(readerPage, game.gameId);
+
+  // Seed the life model from the *computed* expectation, not from the server,
+  // so a wrong starting life (e.g. a missed card life_modifier) fails here.
+  for (const handle of game.players) {
+    const doc = serverPlayerFor(snapshot, handle);
+    const expectedStart = startingLifeFor(config.startingLife, doc.identity_card_id);
+    if ((doc.life_total ?? 0) !== expectedStart) {
+      throw new InvariantViolation(
+        'startingLife',
+        `${handle.name} started at ${doc.life_total} life; ` +
+          `game starting_life ${config.startingLife} + card modifier implies ${expectedStart}`,
+      );
+    }
+    expectations.life.set(handle.userId, expectedStart);
+  }
+
+  let previous: Snapshot | null = null;
+  checkInvariants(previous, snapshot, expectations, false);
+
+  /**
+   * Drive one move through the UI and wait for the server to catch up.
+   * Updates `expectations` with what the move should have done.
+   */
+  const applyMove = async (
+    move: Candidate,
+    step: number,
+    current: Snapshot,
+  ): Promise<{ snapshot: Snapshot; lifeChange: boolean }> => {
+    switch (move.kind) {
+      case 'damage':
+      case 'heal': {
+        const target = move.target!;
+        const amount = move.amount!;
+        const signed = move.kind === 'damage' ? -amount : amount;
+        const before = expectations.life.get(target.userId)!;
+        const after = Math.max(0, before + signed);
+        log.push(
+          `  ${step}. ${move.actor.name} ${move.kind === 'damage' ? '-' : '+'}${amount} → ${target.name} (${before}→${after})`,
+        );
+
+        if (move.kind === 'damage') {
+          await damage(move.actor.page, target.name, amount);
+        } else {
+          await heal(move.actor.page, target.name, amount);
+        }
+        expectations.life.set(target.userId, after);
+        if (after === 0) {
+          expectations.eliminated.add(target.userId);
+          expectations.unveiled.add(target.userId);
+        }
+        return {
+          lifeChange: true,
+          snapshot: await settle(
+            readerPage,
+            game.gameId,
+            (s) => (serverPlayerFor(s, target).life_total ?? -1) === after,
+          ),
+        };
+      }
+
+      case 'unveil': {
+        const actorDoc = serverPlayerFor(current, move.actor);
+        log.push(`  ${step}. ${move.actor.name} unveils (${actorDoc.identity_card_id})`);
+        await unveilSelf(move.actor.page);
+        expectations.unveiled.add(move.actor.userId);
+        let next = await settle(
+          readerPage,
+          game.gameId,
+          (s) => serverPlayerFor(s, move.actor).is_unveiled === true,
+        );
+        const cardId = actorDoc.identity_card_id;
+        if (cardId && (ABILITY_TRAITOR_CARDS as readonly string[]).includes(cardId)) {
+          await handleAbilityModal(move.actor.page, cardId, rng, log);
+          // The resolvers move cards and roles around; re-read before asserting.
+          next = await readSnapshot(readerPage, game.gameId);
+        }
+        return { lifeChange: false, snapshot: next };
+      }
+
+      case 'ability': {
+        const actorDoc = serverPlayerFor(current, move.actor);
+        const cardId = actorDoc.identity_card_id!;
+        log.push(`  ${step}. ${move.actor.name} re-activates ${cardId}`);
+        await move.actor.page.getByRole('button', { name: 'Activate ability' }).click();
+        await handleAbilityModal(move.actor.page, cardId, rng, log);
+        return { lifeChange: false, snapshot: await readSnapshot(readerPage, game.gameId) };
+      }
+
+      case 'forfeit': {
+        log.push(`  ${step}. ${move.actor.name} forfeits`);
+        await forfeit(move.actor.page);
+        expectations.life.set(move.actor.userId, 0);
+        expectations.eliminated.add(move.actor.userId);
+        expectations.unveiled.add(move.actor.userId);
+        return {
+          lifeChange: false,
+          snapshot: await settle(
+            readerPage,
+            game.gameId,
+            (s) => serverPlayerFor(s, move.actor).is_eliminated === true,
+          ),
+        };
+      }
+    }
+  };
+
+  let steps = 0;
+  try {
+    for (; steps < config.maxSteps; steps++) {
+      if (snapshot.game.state !== 'in_progress') break;
+
+      const move = chooseMove(legalMoves(game, snapshot, rng, treachery), rng);
+      if (!move) break;
+
+      previous = snapshot;
+      let lifeChange = false;
+      let ranOut = false;
+
+      try {
+        const outcome = await applyMove(move, steps, snapshot);
+        snapshot = outcome.snapshot;
+        lifeChange = outcome.lifeChange;
+      } catch (error) {
+        // The board unmounts the moment the game ends, so the tail of a
+        // multi-tap burst can land on a page that is already navigating to
+        // /game-over. That is the app behaving correctly — confirm with the
+        // server and stop the run rather than reporting a dead locator.
+        if (!(await isFinished(readerPage, game.gameId))) throw error;
+        log.push('    (game ended mid-action; board unmounted)');
+        snapshot = await readSnapshot(readerPage, game.gameId);
+        lifeChange = move.kind === 'damage' || move.kind === 'heal';
+        ranOut = true;
+      }
+
+      checkInvariants(previous, snapshot, expectations, lifeChange);
+      if (ranOut) {
+        steps++;
+        break;
+      }
+    }
+  } catch (error) {
+    // Re-throw with the whole replay attached — the seed alone reproduces it,
+    // but the move list says what happened without re-running anything.
+    const detail = error instanceof Error ? error.message : String(error);
+    const env = Object.entries(config.repro)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    throw new Error(
+      `Simulation "${config.label}" failed at step ${steps}.\n` +
+        `Reproduce with: ${env} npm run test:e2e -- simulation\n` +
+        `(this game's derived RNG stream: ${config.seed})\n\n` +
+        `${detail}\n\nMoves:\n${log.join('\n')}`,
+    );
+  }
+
+  log.push(
+    `  done after ${steps} step(s); state=${snapshot.game.state} winning_team=${snapshot.game.winning_team ?? 'none'}`,
+  );
+
+  return {
+    steps,
+    finished: snapshot.game.state === 'finished',
+    winningTeam: (snapshot.game.winning_team as string | null) ?? null,
+    log,
+  };
+}

--- a/Treachery/e2e/visibility.spec.ts
+++ b/Treachery/e2e/visibility.spec.ts
@@ -1,0 +1,143 @@
+import { Browser, Page, test, expect } from '@playwright/test';
+import {
+  PlayerHandle,
+  Role,
+  damage,
+  expectServerLife,
+  fetchGameDoc,
+  forfeit,
+  playerWithRole,
+  playersWithRole,
+  setupSeededGame,
+  unveilSelf,
+} from './helpers';
+
+/**
+ * Negative visibility — the "must NOT see" half of a hidden-role game.
+ *
+ * Everything else in the suite asserts that the right thing appears. This file
+ * asserts that the wrong thing doesn't: a concealed player's role and card
+ * must be invisible to everyone else, and the game-over screen's full identity
+ * reveal must be unreachable while the game is still being played.
+ */
+
+const LAYOUT: Role[] = ['leader', 'assassin', 'assassin', 'traitor'];
+// A stable, unique card name to grep for. If this string is ever visible to
+// someone who shouldn't see it, the hidden-role game is broken.
+const TRAITOR_CARD = 'traitor_01';
+const TRAITOR_CARD_NAME = 'The Banisher';
+const STARTING_LIFE = 20;
+
+const roleButton = (page: Page, role: string) =>
+  // PlayerRow labels the role line "<Role> role[, view card]" — and renders
+  // "Role Hidden" instead when the identity is still concealed.
+  page.getByRole('button', { name: new RegExp(`^${role} role`) });
+
+/** Nothing on this page may give away the concealed traitor's identity. */
+async function expectNoTraitorLeak(page: Page) {
+  await expect(page.getByText(TRAITOR_CARD_NAME)).toHaveCount(0);
+  await expect(page.getByText('Traitor')).toHaveCount(0);
+}
+
+test.describe('Concealed identities stay concealed', () => {
+  test('every non-leader role is hidden from the rest of the table until unveiled', async ({
+    browser,
+  }) => {
+    const { players } = await setupSeededGame(browser, LAYOUT, {
+      cardOverrides: { 3: TRAITOR_CARD },
+      startingLife: STARTING_LIFE,
+    });
+    const traitor = playerWithRole(players, 'traitor');
+
+    for (const viewer of players) {
+      // The Leader is public by the rules; nobody else is — not even to
+      // themselves on the roster (their own card lives in the header instead).
+      await expect(roleButton(viewer.page, 'Leader')).toHaveCount(1);
+      await expect(roleButton(viewer.page, 'Assassin')).toHaveCount(0);
+      await expect(roleButton(viewer.page, 'Guardian')).toHaveCount(0);
+      await expect(roleButton(viewer.page, 'Traitor')).toHaveCount(0);
+      await expect(viewer.page.getByText('Role Hidden')).toHaveCount(LAYOUT.length - 1);
+    }
+
+    // The traitor's *card* is likewise invisible to the other three boards.
+    for (const viewer of players.filter((p) => p.userId !== traitor.userId)) {
+      await expect(viewer.page.getByText(TRAITOR_CARD_NAME)).toHaveCount(0);
+    }
+
+    // Unveiling is the only thing that flips it — and only for that player.
+    await unveilSelf(traitor.page);
+    for (const viewer of players) {
+      await expect(roleButton(viewer.page, 'Traitor')).toHaveCount(1);
+      await expect(roleButton(viewer.page, 'Assassin')).toHaveCount(0);
+      await expect(viewer.page.getByText('Role Hidden')).toHaveCount(LAYOUT.length - 2);
+    }
+  });
+});
+
+test.describe('The game-over reveal is unreachable mid-game', () => {
+  // The game-over screen renders every player's role and identity card with no
+  // check on game.state, and three different routes reach it while the game is
+  // still in progress. Each of the three tests below is the same leak from a
+  // different direction.
+
+  async function setup(browser: Browser) {
+    return setupSeededGame(browser, LAYOUT, {
+      cardOverrides: { 3: TRAITOR_CARD },
+      startingLife: STARTING_LIFE,
+    });
+  }
+
+  // FIXME: currently broken — see finding #2. Un-fixme when the bug is fixed.
+  // An eliminated player is a spectator, not a winner: the spectator bar's
+  // "Leave Game" button routes straight to /game-over/, which reveals every
+  // living player's role and card while the game is still in progress.
+  test.fixme('an eliminated spectator pressing Leave Game sees no identities', async ({ browser }) => {
+    const { players, gameId } = await setup(browser);
+    const leader = playerWithRole(players, 'leader');
+    const [assassinA] = playersWithRole(players, 'assassin');
+
+    await damage(leader.page, assassinA.name, STARTING_LIFE);
+    await expectServerLife(leader.page, gameId, assassinA.userId, 0);
+
+    await assassinA.page.getByRole('button', { name: 'Leave game' }).click();
+
+    // The game is still running for everyone else...
+    expect((await fetchGameDoc(leader.page, gameId))?.state).toBe('in_progress');
+    // ...so the eliminated player must not be handed the full reveal.
+    await expectNoTraitorLeak(assassinA.page);
+  });
+
+  // FIXME: currently broken — see finding #2. Un-fixme when the bug is fixed.
+  // Forfeiting navigates the forfeiter to /game-over/ unconditionally, so any
+  // player can trade their own elimination for everyone else's identities.
+  test.fixme('a player who forfeits while the game continues sees no identities', async ({
+    browser,
+  }) => {
+    const { players, gameId } = await setup(browser);
+    const [assassinA] = playersWithRole(players, 'assassin');
+
+    await forfeit(assassinA.page);
+    await expect(assassinA.page).toHaveURL(/\/game-over\//, { timeout: 15_000 });
+
+    // Leader + one assassin + traitor are still alive, so nobody has won.
+    expect((await fetchGameDoc(players[0].page, gameId))?.state).toBe('in_progress');
+    await expectNoTraitorLeak(assassinA.page);
+  });
+
+  // FIXME: currently broken — see finding #2. Un-fixme when the bug is fixed.
+  // On web the route is just a URL. A living player can type
+  // /game-over/<gameId> and read the whole table mid-game.
+  test.fixme('navigating directly to /game-over mid-game reveals nothing', async ({ browser }) => {
+    const { players, gameId } = await setup(browser);
+    const snoop: PlayerHandle = playersWithRole(players, 'assassin')[0];
+
+    expect((await fetchGameDoc(snoop.page, gameId))?.state).toBe('in_progress');
+    await snoop.page.goto(`/game-over/${gameId}`);
+    // Wait for the app to finish booting without prescribing which screen it
+    // settles on — bouncing back to the board is a perfectly good fix. Every
+    // candidate screen lists the players, so this is a neutral "rendered" gate.
+    await expect(snoop.page.getByText('Player 1').first()).toBeVisible({ timeout: 20_000 });
+
+    await expectNoTraitorLeak(snoop.page);
+  });
+});


### PR DESCRIPTION
**PR 4 of 4.** Base is `test/functions-integration` (PR #92).

The existing E2E suite was treachery-only and happy-path — no non-treachery coverage at all, and essentially no "must NOT see" assertions. It also scripted every scenario, so it could only find bugs someone had already thought to look for.

### Simulation harness (`e2e/simulation/`)
Four to eight players make semi-random **legal** moves against a live game, with every invariant asserted after each action — so it reaches states nobody would script.

Invariants: one identity card per player and no duplicates; `role` always matches the held card (roles follow cards through Metamorph and Puppet Master swaps); life never negative; 0 life implies eliminated; elimination and unveiling are one-way; `state` only moves forward; a declared winner is consistent with final roles; and life equals starting life plus the deltas actually applied — which is how a dropped optimistic update gets caught.

Runs are seeded and reproducible. CI uses a pinned seed and 3 games; locally it becomes a real fuzzer:

```bash
SIM_SEED=random SIM_STEPS=60 SIM_REPEAT=25 npm run test:e2e -- simulation
```

The seed is *printed* rather than embedded in the test title, because with `SIM_SEED=random` the collecting process and the worker derive different seeds and Playwright matches tests by title.

### New specs
`non-treachery-modes`, `visibility`, `host-promotion`, `concurrency`.

### 8 fixmes + 2 disabled invariants
All assert correct behaviour for bugs that exist today. Verified by un-fixme-ing everything and re-running: exactly the expected set fails — and the simulation **independently rediscovers** the non-treachery auto-finish bug through random play, arriving at it from a different direction than the hand-written spec.

- a player hitting 0 life ends the game for the whole table, in both Life Tracker and Planechase
- the game-over screen reveals every hidden identity and is reachable mid-game — by an eliminated spectator, by forfeiting, and by navigating directly to `/game-over`
- a server-promoted host cannot start the game, because the lobby freezes `isHost` from a navigation param
- near-simultaneous life adjustments from two players silently drop one

A meta-test prints which invariants are currently disabled, so the known-broken list cannot quietly drift out of date.

**Local run: 31 passed, 8 skipped, 1.4 min** — faster than the previous suite despite ~2× the tests, because the harness dials starting life down to 20 (eliminating a player costs one click per point of life).

🤖 Generated with [Claude Code](https://claude.com/claude-code)