### PR TITLE
Add a Firestore security-rules test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,38 @@ jobs:
       # The unit suite was previously not run in CI at all — it gated nothing.
       - run: npm test
 
+  # ── Firestore Security Rules ─────────────────────────
+  # Tests firestore.rules directly against the emulator. This is the only
+  # layer that can reach rules bugs: the Playwright suite drives the UI,
+  # which only ever takes legitimate paths, so a rule that permits a direct
+  # SDK write no client makes is invisible to it.
+  firestore-rules:
+    name: Firestore Rules
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: firestore-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: firestore-tests/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install firebase-tools
+        run: npm install -g firebase-tools@^15
+
+      - run: npm ci
+      - run: npm test
+
   # ── Playwright E2E ───────────────────────────────────
   e2e:
     name: Web E2E (Playwright)

--- a/firestore-tests/.gitignore
+++ b/firestore-tests/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+firestore-debug.log
+firebase-debug.log

--- a/firestore-tests/.mocharc.json
+++ b/firestore-tests/.mocharc.json
@@ -1,0 +1,7 @@
+{
+  "spec": "test/**/*.test.js",
+  "require": ["./test/setup.js"],
+  "timeout": 30000,
+  "slow": 2000,
+  "recursive": true
+}

--- a/firestore-tests/README.md
+++ b/firestore-tests/README.md
@@ -1,0 +1,119 @@
+# firestore-tests
+
+Security-rules tests for the repo-root [`firestore.rules`](../firestore.rules), run against the
+Firestore emulator with [`@firebase/rules-unit-testing`](https://firebase.google.com/docs/rules/unit-tests).
+
+These tests exercise the rules only. They do not touch Cloud Functions (which use the Admin SDK and
+bypass rules entirely) — see `functions/test/game-logic.test.js` for that layer.
+
+## Running
+
+```bash
+cd firestore-tests
+npm install
+npm test
+```
+
+`npm test` runs `scripts/run-rules-tests.js`, which boots the Firestore emulator via
+`firebase emulators:exec` and runs mocha inside it. One command, no manual emulator step.
+
+Current state of the suite: **79 passing, 8 pending (skipped)**.
+
+### Ports and project id
+
+| | |
+|---|---|
+| Firestore emulator port | **8098** (this suite owns it; the shared root config uses 8087) |
+| Project id | `demo-rules-test` (the Playwright E2E suite uses `demo-test`) |
+| Emulator config | `firestore-tests/firebase.json` — **not** the shared root `firebase.json` |
+
+Nothing here reads or writes the root `firebase.json`, so this suite can run at the same time as the
+web E2E suite and the functions emulator.
+
+### Java
+
+The Firebase emulators require **Java 21+**; `firebase-tools` hard-errors on anything older. Some dev
+machines here default to Java 17, so `scripts/run-rules-tests.js` probes for a suitable JDK
+(`JAVA_HOME`, then Homebrew `openjdk@*`, then the standard JVM directories) and exports `JAVA_HOME`
+before starting the emulator. On CI, where `java` is already 21+, the script is a straight
+passthrough. If it can't find one it fails with an actionable message — install a JDK
+(`brew install openjdk@23`) or set `JAVA_HOME` yourself.
+
+### Other commands
+
+```bash
+npm run test:mocha                       # mocha only; expects an emulator already on 8098
+npx mocha test/users.test.js             # a single spec file
+npx mocha --grep "friend_ids"            # filter by name
+FIRESTORE_DEBUG=1 npm test               # restore the SDK's gRPC logging
+```
+
+Expected `PERMISSION_DENIED` errors from every `assertFails` case are silenced by default
+(`setLogLevel('silent')` in `test/setup.js`) so the mocha reporter stays readable.
+
+## Layout
+
+```
+firebase.json                 emulator config owned by this project (port 8098)
+emulator-bootstrap.rules      deny-all placeholder — NOT the ruleset under test
+.mocharc.json                 spec glob, 30s timeout, root-hook registration
+scripts/run-rules-tests.js    JDK resolution + `firebase emulators:exec` wrapper
+test/helpers.js               test environment, fixture factories, runner rationale
+test/setup.js                 mocha root hooks (shared env, clearFirestore between tests)
+test/users.test.js            /users/{userId}
+test/friend-requests.test.js  /friend_requests/{requestId}
+test/games.test.js            /games/{gameId}
+test/players.test.js          /games/{gameId}/players/{playerId}
+```
+
+`firebase-tools` refuses to reference a rules file outside its own config directory, so
+`firebase.json` points at the local `emulator-bootstrap.rules`. The **real** ruleset under test is
+read from `../firestore.rules` and pushed into the emulator by `initializeTestEnvironment()` in
+`test/helpers.js`. The bootstrap is deny-all on purpose: if that load ever silently fails, the
+positive-path tests break loudly instead of passing against the wrong rules.
+
+## Why mocha
+
+`@firebase/rules-unit-testing` is entirely promise-based and needs real `before`/`after` hooks to
+boot and tear down a shared `RulesTestEnvironment`, so the monorepo's "plain node script + `assert`"
+convention (`functions/test/game-logic.test.js`) doesn't stretch to cover it. Mocha was picked over
+vitest because it's the smaller dependency — no vite/esbuild toolchain — runs CommonJS unchanged like
+the rest of the repo's node code, and provides the `it.skip` marker the vulnerability tests rely on.
+Assertions come from `assertSucceeds` / `assertFails`, so no extra assertion library is needed.
+
+## Test conventions
+
+**Fixtures** are seeded through `withSecurityRulesDisabled` (the `seed()` helper), so setup never
+depends on the rules being correct. Assertions then run through `authedDb(uid)` or `anonDb()`, which
+are ordinary client contexts subject to the rules. `clearFirestore()` runs after every test.
+
+**Positive-path tests are regression guards.** They lock in the legitimate flows — a host editing
+their lobby, a player unveiling themselves, a user creating a friend request — and must never be
+skipped. They also pin down the guards that *do* work today, so a future rules rewrite can't quietly
+drop them.
+
+## Skip convention
+
+Some tests are written against the **correct, secure** expectation for behaviour the current rules
+get wrong. They are marked `it.skip` so CI stays green, each carrying a comment in exactly this
+shape:
+
+```js
+// SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
+it.skip("stops a non-participant from injecting themselves into an in_progress game", async () => {
+```
+
+No test in this suite ever asserts that insecure behaviour is *correct*. When a rule is fixed, delete
+the `.skip` — a one-line change — and the test starts guarding the fix. All 8 have been verified to
+fail against the rules as they stand today, so none of them is a no-op.
+
+| # | Skipped test | What the rules currently allow |
+|---|---|---|
+| 1 | `users` read: another user's PII stays hidden | Any signed-in user, including an anonymous guest, can read every user doc — `email`, `phone_number`, `fcm_token` included |
+| 2 | `games` update: no injection into an `in_progress` game | The join rule has no game-state or membership check, so an outsider can add themselves to a live game |
+| 2 | `games` update: joining a full lobby is refused | The join rule has no capacity check against `max_players` |
+| 2 | `players` read: secret roles stay hidden after an injection | Player-doc reads gate on `uid in player_ids`, so a self-injected outsider can read every player's `role` and `identity_card_id` |
+| 3 | `games` update: `player_ids` can't be rewritten to evict members | `isOnlyAddingSelfToPlayerIds()` never requires existing members be preserved, so anyone can set `player_ids` to `[self]` |
+| 4 | `players` create: no gatecrashing someone else's game | Player `create` checks only `user_id == uid` and null role/card — no membership, capacity, or game-state check, and `life_total` / `order_id` / `display_name` are attacker-chosen |
+| 5 | `users` update: no forcing yourself into a victim's `friend_ids` | `onlyFriendIdsChanged()` lets anyone write another user's doc as long as they end up in the new array |
+| 5 | `users` update: a victim's `friend_ids` can't be wiped | Same helper never requires existing entries be preserved, so `friend_ids` can be overwritten with `[attacker]` |

--- a/firestore-tests/emulator-bootstrap.rules
+++ b/firestore-tests/emulator-bootstrap.rules
@@ -1,0 +1,14 @@
+rules_version = '2';
+
+// Placeholder ruleset the emulator boots with. It is NOT the ruleset under
+// test — test/helpers.js immediately replaces it with the repo-root
+// ../firestore.rules via initializeTestEnvironment(). Deny-all is deliberate:
+// if that replacement ever fails, every positive-path test fails loudly rather
+// than passing against the wrong rules.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/firestore-tests/firebase.json
+++ b/firestore-tests/firebase.json
@@ -1,0 +1,24 @@
+{
+  "_comment": [
+    "Emulator config OWNED BY firestore-tests/. The repo-root firebase.json is shared",
+    "by the web E2E suite and the functions emulator, so this suite keeps its own file",
+    "and its own port (8098) so they can all run at the same time.",
+    "",
+    "firebase-tools refuses to reference a rules file outside the config's own directory,",
+    "so this points at the local deny-all bootstrap. The REAL ruleset under test",
+    "(../firestore.rules) is loaded into the emulator by initializeTestEnvironment() in",
+    "test/helpers.js. The bootstrap denies everything on purpose: if that load ever",
+    "silently fails, the positive-path tests break loudly instead of passing vacuously."
+  ],
+  "firestore": {
+    "rules": "emulator-bootstrap.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8098,
+      "host": "127.0.0.1"
+    },
+    "ui": { "enabled": false },
+    "singleProjectMode": true
+  }
+}

--- a/firestore-tests/package-lock.json
+++ b/firestore-tests/package-lock.json
@@ -1,0 +1,2132 @@
+{
+  "name": "treachery-firestore-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "treachery-firestore-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@firebase/rules-unit-testing": "^5.0.1",
+        "firebase": "^12.16.0",
+        "mocha": "^11.7.6"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.15.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^0.4.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+      "integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.1",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.15",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-compat": "0.2.27",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/firestore-tests/package.json
+++ b/firestore-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "treachery-firestore-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Security-rules tests for the repo-root firestore.rules (Firestore emulator + @firebase/rules-unit-testing)",
+  "scripts": {
+    "test": "node scripts/run-rules-tests.js",
+    "test:mocha": "mocha"
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.1",
+    "firebase": "^12.16.0",
+    "mocha": "^11.7.6"
+  }
+}

--- a/firestore-tests/scripts/run-rules-tests.js
+++ b/firestore-tests/scripts/run-rules-tests.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Boots the Firestore emulator (port 8098) and runs the mocha rules suite
+ * inside it, in one command:  npm test
+ *
+ * Why this wrapper instead of putting `firebase emulators:exec ...` straight
+ * into the npm script (the way Treachery/package.json does for test:e2e):
+ * firebase-tools >= 14 refuses to start the emulators on Java < 21, and the
+ * default `java` on a dev machine here is 17. Rather than hard-coding one
+ * developer's JDK path into package.json, we probe for a Java 21+ runtime and
+ * only then hand off to `firebase emulators:exec`. On a CI image where `java`
+ * is already 21+ this script is a straight passthrough.
+ */
+
+"use strict";
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const PROJECT_ID = "demo-rules-test";
+const TESTS_DIR = path.resolve(__dirname, "..");
+const MIN_JAVA_MAJOR = 21;
+
+/** `java -version` prints to stderr, so both streams have to be inspected. */
+function javaMajorVersion(javaBin) {
+  const res = spawnSync(javaBin, ["-version"], { encoding: "utf8" });
+  if (res.error) return null;
+  return parseMajor(`${res.stdout || ""}${res.stderr || ""}`);
+}
+
+function parseMajor(text) {
+  const match = /version "(\d+)(?:\.(\d+))?/.exec(text || "");
+  if (!match) return null;
+  const major = Number(match[1]);
+  // Legacy scheme: 1.8.x means Java 8
+  if (major === 1 && match[2] !== undefined) return Number(match[2]);
+  return major;
+}
+
+/** Candidate JAVA_HOME directories, most preferred first. */
+function candidateJavaHomes() {
+  const candidates = [];
+  if (process.env.JAVA_HOME) candidates.push(process.env.JAVA_HOME);
+
+  // Homebrew keg-only openjdk formulae, highest version first.
+  for (const optDir of [
+    "/opt/homebrew/opt",
+    "/usr/local/opt",
+    "/home/linuxbrew/.linuxbrew/opt",
+  ]) {
+    let entries;
+    try {
+      entries = fs.readdirSync(optDir).filter((e) => /^openjdk(@\d+)?$/.test(e));
+    } catch {
+      continue;
+    }
+    const suffix = (e) => Number((e.split("@")[1] || "0"));
+    entries.sort((a, b) => suffix(b) - suffix(a));
+    for (const entry of entries) {
+      candidates.push(path.join(optDir, entry, "libexec/openjdk.jdk/Contents/Home"));
+      candidates.push(path.join(optDir, entry));
+    }
+  }
+
+  // Standard JVM install locations.
+  for (const jvmDir of ["/Library/Java/JavaVirtualMachines", "/usr/lib/jvm"]) {
+    try {
+      for (const entry of fs.readdirSync(jvmDir)) {
+        candidates.push(path.join(jvmDir, entry, "Contents/Home"));
+        candidates.push(path.join(jvmDir, entry));
+      }
+    } catch {
+      /* directory absent on this platform */
+    }
+  }
+
+  return candidates;
+}
+
+function resolveJavaHome() {
+  for (const home of candidateJavaHomes()) {
+    const bin = path.join(home, "bin", "java");
+    if (!fs.existsSync(bin)) continue;
+    const major = javaMajorVersion(bin);
+    if (major !== null && major >= MIN_JAVA_MAJOR) return { home, major };
+  }
+  return null;
+}
+
+const env = { ...process.env };
+const ambient = javaMajorVersion("java");
+
+if (ambient === null || ambient < MIN_JAVA_MAJOR) {
+  const found = resolveJavaHome();
+  if (!found) {
+    console.error(
+      `[rules-tests] No Java ${MIN_JAVA_MAJOR}+ runtime found (ambient java: ${ambient ?? "none"}). ` +
+        "The Firebase emulators require one — install it (e.g. `brew install openjdk@23`) " +
+        "or point JAVA_HOME at a suitable JDK."
+    );
+    process.exit(1);
+  }
+  env.JAVA_HOME = found.home;
+  env.PATH = `${path.join(found.home, "bin")}${path.delimiter}${env.PATH}`;
+  console.log(
+    `[rules-tests] ambient java is ${ambient ?? "missing"}; using Java ${found.major} at ${found.home}`
+  );
+}
+
+const result = spawnSync(
+  "npx",
+  [
+    "--no-install",
+    "firebase",
+    "emulators:exec",
+    `--project=${PROJECT_ID}`,
+    "--only",
+    "firestore",
+    "--config=firebase.json",
+    "npx --no-install mocha",
+  ],
+  { cwd: TESTS_DIR, env, stdio: "inherit" }
+);
+
+process.exit(result.status === null ? 1 : result.status);

--- a/firestore-tests/test/friend-requests.test.js
+++ b/firestore-tests/test/friend-requests.test.js
@@ -1,0 +1,118 @@
+/**
+ * Rules under test: match /friend_requests/{requestId}  (firestore.rules ~lines 25-38)
+ */
+
+"use strict";
+
+const { doc, getDoc, setDoc, updateDoc, deleteDoc } = require("firebase/firestore");
+const {
+  seed,
+  authedDb,
+  anonDb,
+  friendRequestDoc,
+  assertSucceeds,
+  assertFails,
+} = require("./helpers");
+
+const ALICE = "user_alice";
+const BOB = "user_bob";
+const MALLORY = "user_mallory";
+const REQ = "req_alice_to_bob";
+
+describe("friend_requests/{requestId}", () => {
+  beforeEach(async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, "friend_requests", REQ), friendRequestDoc(ALICE, BOB));
+    });
+  });
+
+  describe("read", () => {
+    it("lets the sender read their own outgoing request", async () => {
+      const db = await authedDb(ALICE);
+      await assertSucceeds(getDoc(doc(db, "friend_requests", REQ)));
+    });
+
+    it("lets the recipient read an incoming request", async () => {
+      const db = await authedDb(BOB);
+      await assertSucceeds(getDoc(doc(db, "friend_requests", REQ)));
+    });
+
+    it("hides a request from an unrelated user", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(getDoc(doc(db, "friend_requests", REQ)));
+    });
+
+    it("hides a request from a signed-out client", async () => {
+      const db = await anonDb();
+      await assertFails(getDoc(doc(db, "friend_requests", REQ)));
+    });
+  });
+
+  describe("create", () => {
+    it("lets a user send a pending request from their own uid", async () => {
+      const db = await authedDb(ALICE);
+      await assertSucceeds(
+        setDoc(doc(db, "friend_requests", "req_new"), friendRequestDoc(ALICE, MALLORY))
+      );
+    });
+
+    it("stops a user from forging a request from someone else's uid", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        setDoc(doc(db, "friend_requests", "req_forged"), friendRequestDoc(ALICE, BOB))
+      );
+    });
+
+    it("stops a user from creating a pre-accepted request", async () => {
+      const db = await authedDb(ALICE);
+      await assertFails(
+        setDoc(
+          doc(db, "friend_requests", "req_preaccepted"),
+          friendRequestDoc(ALICE, BOB, { status: "accepted" })
+        )
+      );
+    });
+
+    it("stops a signed-out client from creating a request", async () => {
+      const db = await anonDb();
+      await assertFails(
+        setDoc(doc(db, "friend_requests", "req_anon"), friendRequestDoc(ALICE, BOB))
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("lets the recipient accept a request", async () => {
+      const db = await authedDb(BOB);
+      await assertSucceeds(
+        updateDoc(doc(db, "friend_requests", REQ), { status: "accepted" })
+      );
+    });
+
+    it("stops the sender from accepting their own request", async () => {
+      const db = await authedDb(ALICE);
+      await assertFails(
+        updateDoc(doc(db, "friend_requests", REQ), { status: "accepted" })
+      );
+    });
+
+    it("stops an unrelated user from touching the request", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(db, "friend_requests", REQ), { status: "accepted" })
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("denies deletion to the recipient", async () => {
+      const db = await authedDb(BOB);
+      await assertFails(deleteDoc(doc(db, "friend_requests", REQ)));
+    });
+
+    it("denies deletion to the sender", async () => {
+      const db = await authedDb(ALICE);
+      await assertFails(deleteDoc(doc(db, "friend_requests", REQ)));
+    });
+  });
+});

--- a/firestore-tests/test/games.test.js
+++ b/firestore-tests/test/games.test.js
@@ -1,0 +1,242 @@
+/**
+ * Rules under test: match /games/{gameId}  (firestore.rules ~lines 43-67)
+ * plus the isOnlyAddingSelfToPlayerIds() helper (~line 120).
+ */
+
+"use strict";
+
+const { doc, getDoc, setDoc, updateDoc, deleteDoc } = require("firebase/firestore");
+const {
+  seed,
+  authedDb,
+  anonDb,
+  gameDoc,
+  assertSucceeds,
+  assertFails,
+} = require("./helpers");
+
+const HOST = "user_host";
+const PLAYER = "user_player";
+const THIRD = "user_third";
+const OUTSIDER = "user_outsider";
+
+const WAITING = "game_waiting";
+const IN_PROGRESS = "game_in_progress";
+const FULL = "game_full";
+
+describe("games/{gameId}", () => {
+  beforeEach(async () => {
+    await seed(async (db) => {
+      await setDoc(
+        doc(db, "games", WAITING),
+        gameDoc(HOST, { player_ids: [HOST, PLAYER] })
+      );
+      await setDoc(
+        doc(db, "games", IN_PROGRESS),
+        gameDoc(HOST, {
+          state: "in_progress",
+          player_ids: [HOST, PLAYER, THIRD],
+          join_code: "WXYZ",
+        })
+      );
+      await setDoc(
+        doc(db, "games", FULL),
+        gameDoc(HOST, {
+          max_players: 4,
+          player_ids: [HOST, PLAYER, THIRD, "user_fourth"],
+          join_code: "FULL",
+        })
+      );
+    });
+  });
+
+  // ─── read ────────────────────────────────────────────────────────
+  describe("read", () => {
+    it("lets any signed-in user read a lobby (join-by-code flow)", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertSucceeds(getDoc(doc(db, "games", WAITING)));
+    });
+
+    it("denies a signed-out client", async () => {
+      const db = await anonDb();
+      await assertFails(getDoc(doc(db, "games", WAITING)));
+    });
+  });
+
+  // ─── create ──────────────────────────────────────────────────────
+  describe("create", () => {
+    it("lets a user create a game they host, in the waiting state", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertSucceeds(
+        setDoc(doc(db, "games", "game_new"), gameDoc(OUTSIDER))
+      );
+    });
+
+    it("stops a user from creating a game hosted by somebody else", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(setDoc(doc(db, "games", "game_forged"), gameDoc(HOST)));
+    });
+
+    it("stops a user from creating a game that is already in_progress", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        setDoc(
+          doc(db, "games", "game_started"),
+          gameDoc(OUTSIDER, { state: "in_progress" })
+        )
+      );
+    });
+
+    it("stops a signed-out client from creating a game", async () => {
+      const db = await anonDb();
+      await assertFails(setDoc(doc(db, "games", "game_anon"), gameDoc(OUTSIDER)));
+    });
+  });
+
+  // ─── update: host settings ───────────────────────────────────────
+  describe("update (host settings)", () => {
+    it("lets the host change lobby settings while waiting", async () => {
+      const db = await authedDb(HOST);
+      await assertSucceeds(
+        updateDoc(doc(db, "games", WAITING), {
+          max_players: 8,
+          starting_life: 60,
+          max_traitor_rarity: "rare",
+        })
+      );
+    });
+
+    it("stops a non-host from changing lobby settings", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(updateDoc(doc(db, "games", WAITING), { max_players: 8 }));
+    });
+
+    it("stops an outsider from changing lobby settings", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(updateDoc(doc(db, "games", WAITING), { max_players: 8 }));
+    });
+
+    it("stops even the host from editing a game that is already in_progress", async () => {
+      const db = await authedDb(HOST);
+      await assertFails(
+        updateDoc(doc(db, "games", IN_PROGRESS), { max_players: 8 })
+      );
+    });
+
+    it("stops the host from starting the game from the client (Cloud Functions only)", async () => {
+      const db = await authedDb(HOST);
+      await assertFails(
+        updateDoc(doc(db, "games", WAITING), { state: "in_progress" })
+      );
+    });
+
+    it("stops the host from declaring a winning_team from the client", async () => {
+      const db = await authedDb(HOST);
+      await assertFails(
+        updateDoc(doc(db, "games", IN_PROGRESS), {
+          state: "finished",
+          winning_team: "traitor",
+        })
+      );
+    });
+
+    it("stops an outsider from seizing host_id on somebody else's lobby", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, "games", WAITING), { host_id: OUTSIDER })
+      );
+    });
+  });
+
+  // ─── update: joining ─────────────────────────────────────────────
+  describe("update (joining)", () => {
+    it("lets a user join a waiting lobby by appending themselves to player_ids", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertSucceeds(
+        updateDoc(doc(db, "games", WAITING), {
+          player_ids: [HOST, PLAYER, OUTSIDER],
+          last_activity_at: new Date(),
+        })
+      );
+    });
+
+    it("stops a user from adding somebody other than themselves", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, "games", WAITING), {
+          player_ids: [HOST, PLAYER, "user_bystander"],
+        })
+      );
+    });
+
+    it("stops a user from piggybacking other field changes onto a join", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, "games", WAITING), {
+          player_ids: [HOST, PLAYER, OUTSIDER],
+          max_players: 99,
+        })
+      );
+    });
+
+    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
+    it.skip("stops a non-participant from injecting themselves into an in_progress game", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, "games", IN_PROGRESS), {
+          player_ids: [HOST, PLAYER, THIRD, OUTSIDER],
+          last_activity_at: new Date(),
+        })
+      );
+    });
+
+    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
+    it.skip("stops a user from joining a lobby that is already at max_players", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, "games", FULL), {
+          player_ids: [HOST, PLAYER, THIRD, "user_fourth", OUTSIDER],
+          last_activity_at: new Date(),
+        })
+      );
+    });
+
+    // SKIP: currently vulnerable — see finding #3. Un-skip when firestore.rules is fixed.
+    it.skip("stops player_ids from being overwritten in a way that evicts existing members", async () => {
+      // An existing member cannot kick everyone else out...
+      const player = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(player, "games", WAITING), { player_ids: [PLAYER] })
+      );
+
+      // ...and neither can a complete outsider.
+      const outsider = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(outsider, "games", WAITING), { player_ids: [OUTSIDER] })
+      );
+    });
+  });
+
+  // ─── delete ──────────────────────────────────────────────────────
+  describe("delete", () => {
+    it("lets the host disband their own lobby", async () => {
+      const db = await authedDb(HOST);
+      await assertSucceeds(deleteDoc(doc(db, "games", WAITING)));
+    });
+
+    it("stops a non-host player from deleting the lobby", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(deleteDoc(doc(db, "games", WAITING)));
+    });
+
+    it("stops an outsider from deleting the lobby", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(deleteDoc(doc(db, "games", WAITING)));
+    });
+
+    it("stops a signed-out client from deleting the lobby", async () => {
+      const db = await anonDb();
+      await assertFails(deleteDoc(doc(db, "games", WAITING)));
+    });
+  });
+});

--- a/firestore-tests/test/helpers.js
+++ b/firestore-tests/test/helpers.js
@@ -1,0 +1,164 @@
+/**
+ * Shared setup for the Firestore security-rules suite.
+ *
+ * Runner choice: **mocha**.
+ *   `@firebase/rules-unit-testing` is entirely promise-based and needs real
+ *   `before`/`after` hooks to boot and tear down a shared RulesTestEnvironment,
+ *   so the monorepo's "plain node script + assert" convention (see
+ *   functions/test/game-logic.test.js) doesn't fit here. Mocha was picked over
+ *   vitest because it is the smaller dependency (no vite/esbuild toolchain),
+ *   runs CommonJS unchanged like the rest of the repo's node code, and gives us
+ *   the `it.skip` marker the vulnerability tests below rely on. Assertions come
+ *   from `assertSucceeds` / `assertFails` plus node's built-in `assert`, so no
+ *   extra assertion library is needed.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} = require("@firebase/rules-unit-testing");
+
+// Distinct fake project so we never share emulator state with the web E2E
+// suite (which uses `demo-test`).
+const PROJECT_ID = "demo-rules-test";
+
+// This suite owns port 8098. Other suites in the monorepo use 8087 / 8187 /
+// 8288 / 8082, so they can all run concurrently.
+const FIRESTORE_HOST = "127.0.0.1";
+const FIRESTORE_PORT = 8098;
+
+const RULES_PATH = path.resolve(__dirname, "../../firestore.rules");
+
+let testEnv = null;
+
+async function getTestEnv() {
+  if (testEnv) return testEnv;
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      host: FIRESTORE_HOST,
+      port: FIRESTORE_PORT,
+      rules: fs.readFileSync(RULES_PATH, "utf8"),
+    },
+  });
+  return testEnv;
+}
+
+async function cleanupTestEnv() {
+  if (!testEnv) return;
+  await testEnv.cleanup();
+  testEnv = null;
+}
+
+/**
+ * Seed fixture documents with rules bypassed.
+ * @param {(db: import('firebase/firestore').Firestore) => Promise<void>} fn
+ */
+async function seed(fn) {
+  const env = await getTestEnv();
+  await env.withSecurityRulesDisabled(async (context) => {
+    await fn(context.firestore());
+  });
+}
+
+/** Firestore handle for a signed-in user. */
+async function authedDb(uid, tokenOptions) {
+  const env = await getTestEnv();
+  return env.authenticatedContext(uid, tokenOptions).firestore();
+}
+
+/** Firestore handle for a signed-out client. */
+async function anonDb() {
+  const env = await getTestEnv();
+  return env.unauthenticatedContext().firestore();
+}
+
+async function clearData() {
+  const env = await getTestEnv();
+  await env.clearFirestore();
+}
+
+// ─── Fixture factories ──────────────────────────────────────────────
+
+/** A realistic users/{uid} doc — note the PII fields finding #1 is about. */
+function userDoc(uid, overrides = {}) {
+  return {
+    uid,
+    display_name: `Player ${uid}`,
+    email: `${uid}@example.com`,
+    phone_number: "+15555550123",
+    fcm_token: `fcm-token-${uid}`,
+    friend_ids: [],
+    elo_rating: 1200,
+    games_played: 0,
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function gameDoc(hostId, overrides = {}) {
+  return {
+    host_id: hostId,
+    state: "waiting",
+    player_ids: [hostId],
+    max_players: 6,
+    starting_life: 40,
+    game_mode: "standard",
+    max_traitor_rarity: "mythic",
+    join_code: "ABCD",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    last_activity_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function playerDoc(userId, overrides = {}) {
+  return {
+    user_id: userId,
+    display_name: `Player ${userId}`,
+    life_total: 40,
+    order_id: 0,
+    is_unveiled: false,
+    is_eliminated: false,
+    player_color: "#4287f5",
+    commander_name: "",
+    role: null,
+    identity_card_id: null,
+    ...overrides,
+  };
+}
+
+function friendRequestDoc(fromUserId, toUserId, overrides = {}) {
+  return {
+    from_user_id: fromUserId,
+    to_user_id: toUserId,
+    from_display_name: `Player ${fromUserId}`,
+    status: "pending",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+module.exports = {
+  PROJECT_ID,
+  FIRESTORE_HOST,
+  FIRESTORE_PORT,
+  RULES_PATH,
+  getTestEnv,
+  cleanupTestEnv,
+  seed,
+  authedDb,
+  anonDb,
+  clearData,
+  userDoc,
+  gameDoc,
+  playerDoc,
+  friendRequestDoc,
+  assertSucceeds,
+  assertFails,
+};

--- a/firestore-tests/test/players.test.js
+++ b/firestore-tests/test/players.test.js
@@ -1,0 +1,397 @@
+/**
+ * Rules under test: match /games/{gameId}/players/{playerId}
+ * (firestore.rules ~lines 72-110) plus onlyUnveilChanged() /
+ * onlyPlayerColorChanged() / onlyCommanderNameChanged() / isGameHost().
+ *
+ * The player doc is where the game's secrets live: `role` and
+ * `identity_card_id` are what the whole hidden-role format hangs on.
+ */
+
+"use strict";
+
+const { doc, getDoc, setDoc, updateDoc, deleteDoc } = require("firebase/firestore");
+const {
+  seed,
+  authedDb,
+  anonDb,
+  gameDoc,
+  playerDoc,
+  assertSucceeds,
+  assertFails,
+} = require("./helpers");
+
+const HOST = "user_host";
+const PLAYER = "user_player";
+const THIRD = "user_third";
+const JOINER = "user_joiner";
+const OUTSIDER = "user_outsider";
+
+const WAITING = "game_waiting";
+const IN_PROGRESS = "game_in_progress";
+
+const P_HOST = "p_host";
+const P_PLAYER = "p_player";
+const P_THIRD = "p_third";
+
+const waitingPlayer = (gameId, playerId) => ["games", gameId, "players", playerId];
+
+describe("games/{gameId}/players/{playerId}", () => {
+  beforeEach(async () => {
+    await seed(async (db) => {
+      // A lobby that JOINER has already been admitted to (player_ids updated),
+      // but where they have not yet written their player doc.
+      await setDoc(
+        doc(db, "games", WAITING),
+        gameDoc(HOST, { player_ids: [HOST, PLAYER, JOINER] })
+      );
+      await setDoc(
+        doc(db, ...waitingPlayer(WAITING, P_HOST)),
+        playerDoc(HOST, { order_id: 0 })
+      );
+      await setDoc(
+        doc(db, ...waitingPlayer(WAITING, P_PLAYER)),
+        playerDoc(PLAYER, { order_id: 1 })
+      );
+
+      // A live game where roles have been dealt by the Cloud Function.
+      await setDoc(
+        doc(db, "games", IN_PROGRESS),
+        gameDoc(HOST, {
+          state: "in_progress",
+          player_ids: [HOST, PLAYER, THIRD],
+          join_code: "WXYZ",
+        })
+      );
+      await setDoc(
+        doc(db, ...waitingPlayer(IN_PROGRESS, P_HOST)),
+        playerDoc(HOST, { order_id: 0, role: "leader", identity_card_id: "card-leader-1" })
+      );
+      await setDoc(
+        doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)),
+        playerDoc(PLAYER, { order_id: 1, role: "traitor", identity_card_id: "card-traitor-1" })
+      );
+      await setDoc(
+        doc(db, ...waitingPlayer(IN_PROGRESS, P_THIRD)),
+        playerDoc(THIRD, { order_id: 2, role: "assassin", identity_card_id: "card-assassin-1" })
+      );
+    });
+  });
+
+  // ─── read ────────────────────────────────────────────────────────
+  describe("read", () => {
+    it("lets a participant read the other players in their game", async () => {
+      const db = await authedDb(PLAYER);
+      await assertSucceeds(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_HOST))));
+    });
+
+    it("hides player docs from a non-participant", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER))));
+    });
+
+    it("hides player docs from a signed-out client", async () => {
+      const db = await anonDb();
+      await assertFails(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER))));
+    });
+
+    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
+    it.skip("keeps secret roles hidden from an outsider who tries the player_ids injection", async () => {
+      const db = await authedDb(OUTSIDER);
+
+      // Attempt the finding-#2 injection. Once the join rule is fixed this write
+      // is denied outright; today it lands. Either way the read below must fail
+      // — an outsider must never see another player's role / identity_card_id.
+      await updateDoc(doc(db, "games", IN_PROGRESS), {
+        player_ids: [HOST, PLAYER, THIRD, OUTSIDER],
+        last_activity_at: new Date(),
+      }).catch(() => {});
+
+      await assertFails(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER))));
+      await assertFails(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_HOST))));
+    });
+  });
+
+  // ─── create ──────────────────────────────────────────────────────
+  describe("create", () => {
+    it("lets an admitted player create their own player doc with no role or card", async () => {
+      const db = await authedDb(JOINER);
+      await assertSucceeds(
+        setDoc(
+          doc(db, ...waitingPlayer(WAITING, "p_joiner")),
+          playerDoc(JOINER, { order_id: 2 })
+        )
+      );
+    });
+
+    it("accepts a player doc that omits role / identity_card_id entirely (Swift Codable skips nils)", async () => {
+      const db = await authedDb(JOINER);
+      await assertSucceeds(
+        setDoc(doc(db, ...waitingPlayer(WAITING, "p_joiner_slim")), {
+          user_id: JOINER,
+          display_name: "Joiner",
+          life_total: 40,
+          order_id: 2,
+          is_unveiled: false,
+          is_eliminated: false,
+        })
+      );
+    });
+
+    it("stops a user from creating a player doc for somebody else", async () => {
+      const db = await authedDb(JOINER);
+      await assertFails(
+        setDoc(
+          doc(db, ...waitingPlayer(WAITING, "p_impostor")),
+          playerDoc(OUTSIDER, { order_id: 2 })
+        )
+      );
+    });
+
+    it("stops a player from dealing themselves a role", async () => {
+      const db = await authedDb(JOINER);
+      await assertFails(
+        setDoc(
+          doc(db, ...waitingPlayer(WAITING, "p_joiner")),
+          playerDoc(JOINER, { role: "traitor" })
+        )
+      );
+    });
+
+    it("stops a player from picking their own identity card", async () => {
+      const db = await authedDb(JOINER);
+      await assertFails(
+        setDoc(
+          doc(db, ...waitingPlayer(WAITING, "p_joiner")),
+          playerDoc(JOINER, { identity_card_id: "card-traitor-1" })
+        )
+      );
+    });
+
+    it("stops a signed-out client from creating a player doc", async () => {
+      const db = await anonDb();
+      await assertFails(
+        setDoc(doc(db, ...waitingPlayer(WAITING, "p_anon")), playerDoc(JOINER))
+      );
+    });
+
+    // SKIP: currently vulnerable — see finding #4. Un-skip when firestore.rules is fixed.
+    it.skip("stops a non-member from creating a player doc in somebody else's in_progress game", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        setDoc(
+          doc(db, ...waitingPlayer(IN_PROGRESS, "p_gatecrasher")),
+          playerDoc(OUTSIDER, {
+            display_name: "GATECRASHER",
+            life_total: 9999,
+            order_id: -1,
+          })
+        )
+      );
+    });
+  });
+
+  // ─── update ──────────────────────────────────────────────────────
+  describe("update (unveil)", () => {
+    it("lets a player unveil themselves", async () => {
+      const db = await authedDb(PLAYER);
+      await assertSucceeds(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          is_unveiled: true,
+        })
+      );
+    });
+
+    it("stops a player from re-hiding themselves after unveiling", async () => {
+      await seed(async (db) => {
+        await setDoc(
+          doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)),
+          playerDoc(PLAYER, {
+            order_id: 1,
+            role: "traitor",
+            identity_card_id: "card-traitor-1",
+            is_unveiled: true,
+          })
+        );
+      });
+
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          is_unveiled: false,
+        })
+      );
+    });
+
+    it("stops a player from unveiling somebody else", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_HOST)), {
+          is_unveiled: true,
+        })
+      );
+    });
+
+    it("stops the host from unveiling another player", async () => {
+      const db = await authedDb(HOST);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          is_unveiled: true,
+        })
+      );
+    });
+
+    it("stops life_total being smuggled in alongside an unveil", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          is_unveiled: true,
+          life_total: 100,
+        })
+      );
+    });
+  });
+
+  describe("update (cosmetics)", () => {
+    it("lets a player set their own player_color", async () => {
+      const db = await authedDb(PLAYER);
+      await assertSucceeds(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          player_color: "#ff0055",
+        })
+      );
+    });
+
+    it("lets a player set their own commander_name", async () => {
+      const db = await authedDb(PLAYER);
+      await assertSucceeds(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          commander_name: "Edgar Markov",
+        })
+      );
+    });
+
+    it("rejects a player_color write that also changes life_total", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          player_color: "#ff0055",
+          life_total: 999,
+        })
+      );
+    });
+
+    it("rejects a commander_name write that also changes role", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          commander_name: "Edgar Markov",
+          role: "leader",
+        })
+      );
+    });
+
+    it("stops a player from recolouring somebody else", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_HOST)), {
+          player_color: "#000000",
+        })
+      );
+    });
+
+    it("stops a non-participant from recolouring a player", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          player_color: "#000000",
+        })
+      );
+    });
+  });
+
+  describe("update (game state stays server-side)", () => {
+    it("stops a player from editing their own life_total", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          life_total: 100,
+        })
+      );
+    });
+
+    it("stops a player from editing somebody else's life_total", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_HOST)), { life_total: 0 })
+      );
+    });
+
+    it("stops a player from changing their own elimination flag", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          is_eliminated: true,
+        })
+      );
+    });
+
+    it("stops a player from rerolling their own role", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          role: "leader",
+        })
+      );
+    });
+
+    it("stops a player from swapping their own identity_card_id", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER)), {
+          identity_card_id: "card-leader-1",
+        })
+      );
+    });
+
+    it("stops a signed-out client from updating a player doc", async () => {
+      const db = await anonDb();
+      await assertFails(
+        updateDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)), {
+          player_color: "#000000",
+        })
+      );
+    });
+  });
+
+  // ─── delete ──────────────────────────────────────────────────────
+  describe("delete", () => {
+    it("lets a player leave by deleting their own player doc", async () => {
+      const db = await authedDb(PLAYER);
+      await assertSucceeds(
+        deleteDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)))
+      );
+    });
+
+    it("lets the host kick any player in their own lobby", async () => {
+      const db = await authedDb(HOST);
+      await assertSucceeds(
+        deleteDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER)))
+      );
+    });
+
+    it("stops a player from kicking another player", async () => {
+      const db = await authedDb(PLAYER);
+      await assertFails(deleteDoc(doc(db, ...waitingPlayer(WAITING, P_HOST))));
+    });
+
+    it("stops a non-participant from deleting a player doc", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertFails(deleteDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER))));
+    });
+
+    it("stops a signed-out client from deleting a player doc", async () => {
+      const db = await anonDb();
+      await assertFails(deleteDoc(doc(db, ...waitingPlayer(WAITING, P_PLAYER))));
+    });
+  });
+});

--- a/firestore-tests/test/setup.js
+++ b/firestore-tests/test/setup.js
@@ -1,0 +1,27 @@
+/**
+ * Mocha root hooks: one shared RulesTestEnvironment for the whole run,
+ * wiped between tests so each spec starts from a known fixture state.
+ */
+
+"use strict";
+
+const { setLogLevel } = require("firebase/firestore");
+const { getTestEnv, cleanupTestEnv, clearData } = require("./helpers");
+
+// Every assertFails() case makes the SDK log a PERMISSION_DENIED gRPC error.
+// Those are the expected result here, and they drown out the mocha reporter.
+// Set FIRESTORE_DEBUG=1 to get them back while debugging a rule.
+setLogLevel(process.env.FIRESTORE_DEBUG ? "debug" : "silent");
+
+exports.mochaHooks = {
+  async beforeAll() {
+    this.timeout(60000);
+    await getTestEnv();
+  },
+  async afterEach() {
+    await clearData();
+  },
+  async afterAll() {
+    await cleanupTestEnv();
+  },
+};

--- a/firestore-tests/test/users.test.js
+++ b/firestore-tests/test/users.test.js
@@ -1,0 +1,165 @@
+/**
+ * Rules under test: match /users/{userId}  (firestore.rules ~lines 9-20)
+ * plus the onlyFriendIdsChanged() / onlyFcmTokenChanged() helpers.
+ */
+
+"use strict";
+
+const { doc, getDoc, setDoc, updateDoc, deleteDoc } = require("firebase/firestore");
+const {
+  seed,
+  authedDb,
+  anonDb,
+  userDoc,
+  assertSucceeds,
+  assertFails,
+} = require("./helpers");
+
+const ALICE = "user_alice";
+const BOB = "user_bob";
+const MALLORY = "user_mallory";
+const CAROL = "user_carol";
+const DAVE = "user_dave";
+
+describe("users/{userId}", () => {
+  beforeEach(async () => {
+    await seed(async (db) => {
+      await setDoc(doc(db, "users", ALICE), userDoc(ALICE));
+      await setDoc(doc(db, "users", BOB), userDoc(BOB, { friend_ids: [CAROL] }));
+      await setDoc(doc(db, "users", MALLORY), userDoc(MALLORY));
+    });
+  });
+
+  // ─── read ────────────────────────────────────────────────────────
+  describe("read", () => {
+    it("lets a user read their own profile", async () => {
+      const db = await authedDb(ALICE);
+      await assertSucceeds(getDoc(doc(db, "users", ALICE)));
+    });
+
+    it("denies a signed-out client any user profile", async () => {
+      const db = await anonDb();
+      await assertFails(getDoc(doc(db, "users", ALICE)));
+    });
+
+    // SKIP: currently vulnerable — see finding #1. Un-skip when firestore.rules is fixed.
+    it.skip("denies a signed-in user access to another user's PII (email / phone_number / fcm_token)", async () => {
+      const mallory = await authedDb(MALLORY);
+      await assertFails(getDoc(doc(mallory, "users", BOB)));
+
+      // The same hole is open to an anonymous guest account, which needs no
+      // real identity at all.
+      const guest = await authedDb("anon_guest_9f2c");
+      await assertFails(getDoc(doc(guest, "users", BOB)));
+    });
+  });
+
+  // ─── create ──────────────────────────────────────────────────────
+  describe("create", () => {
+    it("lets a user create their own profile document", async () => {
+      const db = await authedDb(DAVE);
+      await assertSucceeds(setDoc(doc(db, "users", DAVE), userDoc(DAVE)));
+    });
+
+    it("stops a user from creating a profile under someone else's uid", async () => {
+      const db = await authedDb(DAVE);
+      await assertFails(setDoc(doc(db, "users", "user_erin"), userDoc("user_erin")));
+    });
+
+    it("stops a signed-out client from creating a profile", async () => {
+      const db = await anonDb();
+      await assertFails(setDoc(doc(db, "users", DAVE), userDoc(DAVE)));
+    });
+  });
+
+  // ─── update ──────────────────────────────────────────────────────
+  describe("update", () => {
+    it("lets a user update their own profile fields", async () => {
+      const db = await authedDb(ALICE);
+      await assertSucceeds(
+        updateDoc(doc(db, "users", ALICE), { display_name: "Alice the Brave" })
+      );
+    });
+
+    it("lets a user rotate their own fcm_token", async () => {
+      const db = await authedDb(ALICE);
+      await assertSucceeds(
+        updateDoc(doc(db, "users", ALICE), { fcm_token: "fcm-token-rotated" })
+      );
+    });
+
+    it("lets a user edit their own friend_ids", async () => {
+      const db = await authedDb(BOB);
+      await assertSucceeds(
+        updateDoc(doc(db, "users", BOB), { friend_ids: [CAROL, ALICE] })
+      );
+    });
+
+    it("stops a user from editing another user's display_name", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(db, "users", BOB), { display_name: "pwned" })
+      );
+    });
+
+    it("stops a user from writing another user's fcm_token (push-notification hijack)", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(db, "users", BOB), { fcm_token: "attacker-device" })
+      );
+    });
+
+    it("stops a user from rewriting another user's friend_ids to a list that excludes them", async () => {
+      // The one guard onlyFriendIdsChanged() does apply: the caller must end up
+      // inside the new array. This locks that guard in place.
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(db, "users", BOB), { friend_ids: ["user_someone_else"] })
+      );
+    });
+
+    it("stops a user from smuggling extra fields alongside a friend_ids write", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(db, "users", BOB), {
+          friend_ids: [CAROL, MALLORY],
+          elo_rating: 9999,
+        })
+      );
+    });
+
+    it("stops a signed-out client from updating a profile", async () => {
+      const db = await anonDb();
+      await assertFails(updateDoc(doc(db, "users", ALICE), { display_name: "x" }));
+    });
+
+    // SKIP: currently vulnerable — see finding #5. Un-skip when firestore.rules is fixed.
+    it.skip("stops a user from forcing themselves into another user's friend_ids", async () => {
+      const mallory = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(mallory, "users", BOB), { friend_ids: [CAROL, MALLORY] })
+      );
+    });
+
+    // SKIP: currently vulnerable — see finding #5. Un-skip when firestore.rules is fixed.
+    it.skip("stops a user from overwriting another user's friend_ids and wiping their real friends", async () => {
+      const mallory = await authedDb(MALLORY);
+      await assertFails(
+        updateDoc(doc(mallory, "users", BOB), { friend_ids: [MALLORY] })
+      );
+    });
+  });
+
+  // ─── delete ──────────────────────────────────────────────────────
+  describe("delete", () => {
+    it("denies deletion even to the profile's owner", async () => {
+      const db = await authedDb(ALICE);
+      await assertFails(deleteDoc(doc(db, "users", ALICE)));
+    });
+
+    it("denies deletion to another user", async () => {
+      const db = await authedDb(MALLORY);
+      await assertFails(deleteDoc(doc(db, "users", BOB)));
+    });
+  });
+});


### PR DESCRIPTION
**PR 2 of 4** in the test-harness series. Targets `main` directly (PR #90 has merged).

The repo had **no rules tests**. The Playwright suite drives the app UI, which only ever takes legitimate paths, so a rule permitting a direct SDK write that no client makes is *structurally invisible* to it. This adds the missing layer: `firestore-tests/` runs `firestore.rules` against the emulator with `@firebase/rules-unit-testing` in **~3 seconds**, no browser.

### 79 passing regression guards
Host-only settings, unveil-true-only, `player_color`/`commander_name` isolation (including rejecting writes that piggyback `life_total` or `role`), server-only `life_total`/`role`/`identity_card_id`, friend-request sender checks, participant-scoped player reads.

### 8 skipped tests = an executable punch list
Each asserts the **secure** expectation for a vulnerability that exists today, so un-skipping is a one-line change once a rule is fixed — no test rewrite. Verified by un-skipping all 8 and re-running: **exactly 8 fail**, so none is a no-op.

| Vulnerability | Today |
|---|---|
| User PII | any signed-in user — including anonymous guests — reads every user doc, exposing `email`, `phone_number`, `fcm_token` |
| Game injection | a non-participant can add themselves to an `in_progress` game's `player_ids`, then read every player's secret `role` and `identity_card_id` |
| Capacity | the join rule has no `max_players` check, so a full lobby can be joined by direct write |
| Eviction | `player_ids` can be overwritten wholesale, removing everyone else |
| Player docs | can be created in any game with attacker-chosen `life_total`/`order_id`/`display_name` |
| Friend lists | a victim's `friend_ids` can be force-added to, or wiped entirely |

These are all pre-existing and unrelated to any recent feature.

### One config note worth reviewing
`firebase-tools` refuses a rules path outside its own config directory, so `firestore-tests/firebase.json` points at a **deny-all** bootstrap ruleset, and the real `../firestore.rules` is loaded into the emulator by `initializeTestEnvironment()`. Deny-all is deliberate: if that load ever silently fails, the 79 positive tests fail loudly instead of passing against no rules at all. Confirmed working — denials cite real line numbers from the actual file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
