### PR TITLE
Harden the player_ids and friend_ids rules

### DIFF
--- a/firestore-tests/test/games.test.js
+++ b/firestore-tests/test/games.test.js
@@ -178,9 +178,7 @@ describe("games/{gameId}", () => {
         })
       );
     });
-
-    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
-    it.skip("stops a non-participant from injecting themselves into an in_progress game", async () => {
+    it("stops a non-participant from injecting themselves into an in_progress game", async () => {
       const db = await authedDb(OUTSIDER);
       await assertFails(
         updateDoc(doc(db, "games", IN_PROGRESS), {
@@ -189,9 +187,7 @@ describe("games/{gameId}", () => {
         })
       );
     });
-
-    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
-    it.skip("stops a user from joining a lobby that is already at max_players", async () => {
+    it("stops a user from joining a lobby that is already at max_players", async () => {
       const db = await authedDb(OUTSIDER);
       await assertFails(
         updateDoc(doc(db, "games", FULL), {
@@ -200,9 +196,7 @@ describe("games/{gameId}", () => {
         })
       );
     });
-
-    // SKIP: currently vulnerable — see finding #3. Un-skip when firestore.rules is fixed.
-    it.skip("stops player_ids from being overwritten in a way that evicts existing members", async () => {
+    it("stops player_ids from being overwritten in a way that evicts existing members", async () => {
       // An existing member cannot kick everyone else out...
       const player = await authedDb(PLAYER);
       await assertFails(

--- a/firestore-tests/test/players.test.js
+++ b/firestore-tests/test/players.test.js
@@ -93,9 +93,7 @@ describe("games/{gameId}/players/{playerId}", () => {
       const db = await anonDb();
       await assertFails(getDoc(doc(db, ...waitingPlayer(IN_PROGRESS, P_PLAYER))));
     });
-
-    // SKIP: currently vulnerable — see finding #2. Un-skip when firestore.rules is fixed.
-    it.skip("keeps secret roles hidden from an outsider who tries the player_ids injection", async () => {
+    it("keeps secret roles hidden from an outsider who tries the player_ids injection", async () => {
       const db = await authedDb(OUTSIDER);
 
       // Attempt the finding-#2 injection. Once the join rule is fixed this write

--- a/firestore-tests/test/users.test.js
+++ b/firestore-tests/test/users.test.js
@@ -133,16 +133,18 @@ describe("users/{userId}", () => {
       await assertFails(updateDoc(doc(db, "users", ALICE), { display_name: "x" }));
     });
 
-    // SKIP: currently vulnerable — see finding #5. Un-skip when firestore.rules is fixed.
+    // SKIP: residual gap after the friend_ids hardening — the wipe is now
+    // blocked, but a one-sided friendship can still be forced. Rules cannot
+    // verify an accepted friend_request (random doc ids, so no deterministic
+    // get() path), so closing this means moving accept/remove into a callable
+    // and denying cross-user writes entirely. Un-skip then.
     it.skip("stops a user from forcing themselves into another user's friend_ids", async () => {
       const mallory = await authedDb(MALLORY);
       await assertFails(
         updateDoc(doc(mallory, "users", BOB), { friend_ids: [CAROL, MALLORY] })
       );
     });
-
-    // SKIP: currently vulnerable — see finding #5. Un-skip when firestore.rules is fixed.
-    it.skip("stops a user from overwriting another user's friend_ids and wiping their real friends", async () => {
+    it("stops a user from overwriting another user's friend_ids and wiping their real friends", async () => {
       const mallory = await authedDb(MALLORY);
       await assertFails(
         updateDoc(doc(mallory, "users", BOB), { friend_ids: [MALLORY] })

--- a/firestore.rules
+++ b/firestore.rules
@@ -117,21 +117,65 @@ service cloud.firestore {
       return get(/databases/$(database)/documents/games/$(gameId)).data.host_id == request.auth.uid;
     }
 
+    // True only for a write that appends the CALLER to an open lobby's
+    // player_ids, leaving every existing member in place.
+    //
+    // The previous version checked only which keys changed plus "the caller
+    // ends up in the new array", which permitted any array whatsoever. That
+    // let a non-participant add themselves to an in_progress game and then
+    // read every player's secret role (player docs are gated on membership),
+    // overwrite player_ids to evict the whole table, or walk past max_players.
+    //
+    // Joins normally go through the joinGame callable, which enforces all of
+    // this in a transaction. This path is kept — rather than denied outright —
+    // because older iOS/Android builds in the wild may still write directly,
+    // and a legitimate join from one of those must keep working.
     function isOnlyAddingSelfToPlayerIds() {
-      let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
-      return affectedKeys.hasOnly(['player_ids', 'last_activity_at'])
-        && request.auth.uid in request.resource.data.player_ids;
+      let before = resource.data.player_ids;
+      let after = request.resource.data.player_ids;
+      let cap = 'max_players' in resource.data ? resource.data.max_players : 8;
+      return request.resource.data.diff(resource.data).affectedKeys()
+               .hasOnly(['player_ids', 'last_activity_at'])
+        // The lobby must still be open.
+        && resource.data.state == 'waiting'
+        // Append-only: everyone already seated stays seated.
+        && after.hasAll(before)
+        && after.size() == before.size() + 1
+        // ...and the single addition is the caller, joining for the first time.
+        && !(request.auth.uid in before)
+        && request.auth.uid in after
+        // Mirror the capacity joinGame enforces so a direct write can't bypass it.
+        && after.size() <= cap;
     }
 
+    // Friendship is mutual, so accepting a request writes friend_ids on BOTH
+    // user docs — which means a user must be able to touch someone else's doc.
+    // The previous version allowed that whenever the caller ended up in the new
+    // array, without requiring the existing entries survive, so anyone could
+    // overwrite a victim's friend_ids with [attacker] and wipe their friends.
+    //
+    // Cross-user writes are now append-only and limited to the caller.
+    //
+    // Residual gap: this still permits forcing a one-sided friendship without
+    // an accepted request. Rules cannot check for one — friend_requests use
+    // random document ids, so there is no deterministic get() path. Closing
+    // that requires moving accept/remove into a callable, which would also fix
+    // removeFriend (its arrayRemove on the friend's doc cannot satisfy any
+    // version of this rule, since the caller is absent from the result).
     function onlyFriendIdsChanged(userId) {
-      let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
-      // Only allow friend_ids changes if the caller is adding/removing themselves
-      // from the target user's friend list (mutual friendship operations).
-      // The caller must appear in the new friend_ids list to prevent
-      // arbitrary modification of other users' friend lists.
-      return affectedKeys.hasOnly(['friend_ids'])
-        && (request.auth.uid == userId
-            || request.auth.uid in request.resource.data.friend_ids);
+      let before = resource.data.friend_ids;
+      let after = request.resource.data.friend_ids;
+      return request.resource.data.diff(resource.data).affectedKeys()
+               .hasOnly(['friend_ids'])
+        && (
+          // Owners edit their own list freely.
+          request.auth.uid == userId
+          // Anyone else may only append themselves, preserving what is there.
+          || (after.hasAll(before)
+              && after.size() == before.size() + 1
+              && !(request.auth.uid in before)
+              && request.auth.uid in after)
+        );
     }
 
     function onlyFcmTokenChanged(userId) {


### PR DESCRIPTION
Closes 5 of the 8 vulnerabilities the rules suite documents. **These are live on production today** — rules are project-level, so merging deploys the fix for real users via the existing staging workflow.

### The bug pattern
Both helpers checked *which keys* a write touched but never what the new value contained **relative to the old**. So `"only player_ids changed"` passed just as readily for an arbitrary replacement array as for appending yourself.

### `isOnlyAddingSelfToPlayerIds`
Now requires: the lobby is still `waiting`; the write is append-only (new array is a superset of the old and exactly one longer); the single addition is the caller joining for the first time; and the result respects `max_players`.

That closes four holes at once — injecting yourself into an `in_progress` game (and thereby reading every player's secret role, since player docs are gated on membership), evicting the whole table by overwriting the array, and walking past capacity that only `joinGame` was enforcing.

**Hardened rather than denied outright.** Every current client joins through the `joinGame` callable — the web helper for the direct write is dead code — but older iOS and Android builds are live in TestFlight and Play, and a legitimate join from one of those has to keep working.

### `onlyFriendIdsChanged`
Cross-user writes are now append-only and limited to the caller, so a victim's friend list can't be wiped. Writing another user's doc must stay possible at all, because friendship is mutual and accepting writes both sides.

### Tests
**84 passing, 3 pending** (was 79/8). All 79 pre-existing positive tests still pass — including `"lets a user join a waiting lobby by appending themselves to player_ids"`, the case most at risk from tightening this rule.

### Three tests stay skipped, and their comments now say why
- **Forcing a one-sided friendship is still possible.** Only the wipe is blocked. Rules can't verify an accepted `friend_request` — those use random document ids, so there's no deterministic `get()` path. Closing it means moving accept/remove into a callable, which would also fix `removeFriend` (its `arrayRemove` on the friend's doc can't satisfy *any* version of this rule, since the caller is absent from the result).
- **Player-doc gatecrashing** needs the host's own `create-game.tsx` path moved server-side first.
- **PII reads** need `email`/`phone_number`/`fcm_token` split into an owner-only subcollection, since rules can't withhold individual fields.

### Verification
The emulator loads the real `firestore.rules`, so a tightened rule could break live app flows. Ran the full E2E suite as an A/B against `main`:

| Branch | Machine | Result | Slowest join |
|---|---|---|---|
| main (control) | quiet | 31 passed, 0 failed | 3.5s |
| this branch | quiet | 31 passed, 0 failed | 3.0s |

Identical. Earlier runs of this branch showed join timeouts, but those correlated with machine load (a CI watcher running alongside), not the rules: `joinGame` uses the Admin SDK and never evaluates rules, there were zero permission denials, and zero function errors across 240 executions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)