### PR TITLE
Add a manual playtest harness

### DIFF
--- a/Treachery/e2e/playground.spec.ts
+++ b/Treachery/e2e/playground.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+import {
+  GameMode,
+  PlayerHandle,
+  ROLE_DISTRIBUTION,
+  Role,
+  setupLobby,
+  setupNonTreacheryGame,
+  setupSeededGame,
+} from './helpers';
+
+/**
+ * Manual playtest harness — NOT a test.
+ *
+ * Opens one real, signed-in browser window per player, walks them into a
+ * lobby (and optionally starts the game), prints who is who, then parks on
+ * `page.pause()` so you can click around by hand. It replaces opening N
+ * browsers and signing into each one.
+ *
+ * Run it:
+ *
+ *   npm run playtest                      # 4-player treachery, seeded roles
+ *   PLAYTEST_PLAYERS=6 npm run playtest
+ *   PLAYTEST_MODE=none npm run playtest   # Life Tracker
+ *   PLAYTEST_START=lobby npm run playtest # stop in the lobby, don't start
+ *   PLAYTEST_START=real npm run playtest  # real Start button, random roles
+ *   npm run playtest:nobuild              # skip the web rebuild (~30s faster)
+ *
+ *   PLAYTEST_PLAYERS  4-8                       (default 4)
+ *   PLAYTEST_MODE     treachery | treachery_planechase | planechase | none
+ *                                               (default treachery)
+ *   PLAYTEST_LIFE     multiple of 5             (default 40)
+ *   PLAYTEST_START    seeded | real | lobby     (default seeded)
+ *
+ * This file is excluded from the CI suite (see `testIgnore` in
+ * playwright.config.ts) — it never terminates on its own, by design.
+ */
+
+const PLAYERS = Number.parseInt(process.env.PLAYTEST_PLAYERS ?? '4', 10);
+const MODE = (process.env.PLAYTEST_MODE ?? 'treachery') as GameMode;
+const LIFE = Number.parseInt(process.env.PLAYTEST_LIFE ?? '40', 10);
+const START = (process.env.PLAYTEST_START ?? 'seeded') as 'seeded' | 'real' | 'lobby';
+
+const IS_TREACHERY = MODE === 'treachery' || MODE === 'treachery_planechase';
+
+/**
+ * Expand the role distribution for a player count into a positional layout.
+ * Deterministic on purpose: player 1 (the host) is always the Leader, so you
+ * know where to look without hunting. Use PLAYTEST_START=real for a genuinely
+ * random assignment.
+ */
+function roleLayout(playerCount: number): Role[] {
+  const dist = ROLE_DISTRIBUTION[playerCount];
+  if (!dist) throw new Error(`Unsupported player count: ${playerCount} (4-8)`);
+  const layout: Role[] = [];
+  (['leader', 'guardian', 'assassin', 'traitor'] as Role[]).forEach((role) => {
+    for (let i = 0; i < dist[role]; i++) layout.push(role);
+  });
+  return layout;
+}
+
+function banner(lines: string[]) {
+  const width = Math.max(...lines.map((l) => l.length));
+  console.log(`\n┌${'─'.repeat(width + 2)}┐`);
+  for (const l of lines) console.log(`│ ${l.padEnd(width)} │`);
+  console.log(`└${'─'.repeat(width + 2)}┘\n`);
+}
+
+test('playground', async ({ browser }) => {
+  if (IS_TREACHERY && START === 'seeded' && (PLAYERS < 4 || PLAYERS > 8)) {
+    throw new Error(
+      `Seeded treachery needs 4-8 players (got ${PLAYERS}). ` +
+        `Use PLAYTEST_START=real or PLAYTEST_START=lobby for other counts.`,
+    );
+  }
+
+  let players: PlayerHandle[];
+  let gameId: string;
+  let code: string;
+
+  if (START === 'lobby') {
+    const lobby = await setupLobby(browser, PLAYERS, { mode: MODE, startingLife: LIFE });
+    ({ gameId, code } = lobby);
+    players = lobby.pages.map((page, i) => ({
+      name: lobby.names[i],
+      page,
+      userId: lobby.userIds[i],
+      role: null,
+      identityCardId: null,
+    }));
+  } else if (!IS_TREACHERY) {
+    const game = await setupNonTreacheryGame(
+      browser,
+      PLAYERS,
+      MODE as Exclude<GameMode, 'treachery' | 'treachery_planechase'>,
+      { startingLife: LIFE },
+    );
+    ({ players, gameId, code } = game);
+  } else if (START === 'real') {
+    // Real Start button: the server assigns roles and cards at random, which
+    // is what you want when you're eyeballing the actual dealing logic.
+    const lobby = await setupLobby(browser, PLAYERS, { mode: MODE, startingLife: LIFE });
+    const [hostPage] = lobby.pages;
+    await expect(hostPage.getByRole('button', { name: 'Start game' })).toBeEnabled();
+    await hostPage.getByRole('button', { name: 'Start game' }).click();
+    await Promise.all(
+      lobby.pages.map((p) => expect(p).toHaveURL(/\/game\//, { timeout: 20_000 })),
+    );
+    ({ gameId, code } = lobby);
+    players = lobby.pages.map((page, i) => ({
+      name: lobby.names[i],
+      page,
+      userId: lobby.userIds[i],
+      role: null, // assigned server-side; unknown to us here
+      identityCardId: null,
+    }));
+  } else {
+    const game = await setupSeededGame(browser, roleLayout(PLAYERS), { startingLife: LIFE });
+    ({ players, gameId, code } = game);
+  }
+
+  banner([
+    `game code   ${code}`,
+    `mode        ${MODE}`,
+    `players     ${PLAYERS}`,
+    `life        ${LIFE}`,
+    `start       ${START}`,
+    `gameId      ${gameId}`,
+    '',
+    ...players.map((p) => {
+      const who = p.role ? `${p.role}${p.identityCardId ? ` (${p.identityCardId})` : ''}` : '—';
+      return `${p.name.padEnd(10)} ${who}`;
+    }),
+    '',
+    'All windows are signed in and live. Click around.',
+    'Press Resume in the Playwright Inspector, or close it, to tear down.',
+  ]);
+
+  // Parks here indefinitely (timeout is 0 in the playground config) with every
+  // browser window interactive.
+  await players[0].page.pause();
+});

--- a/Treachery/package.json
+++ b/Treachery/package.json
@@ -14,7 +14,9 @@
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"app/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"app/**/*.{ts,tsx}\"",
-    "test:e2e": "firebase emulators:exec --project=demo-test --only auth,firestore,functions --config=../firebase.json 'npm run build:web:emulator && playwright test'"
+    "test:e2e": "firebase emulators:exec --project=demo-test --only auth,firestore,functions --config=../firebase.json 'npm run build:web:emulator && playwright test'",
+    "playtest": "firebase emulators:exec --project=demo-test --only auth,firestore,functions --config=../firebase.json 'npm run build:web:emulator && playwright test --config=playwright.playground.config.ts'",
+    "playtest:nobuild": "firebase emulators:exec --project=demo-test --only auth,firestore,functions --config=../firebase.json 'playwright test --config=playwright.playground.config.ts'"
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.6",

--- a/Treachery/playwright.config.ts
+++ b/Treachery/playwright.config.ts
@@ -13,6 +13,10 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  // The manual playtest harness parks on page.pause() and never terminates by
+  // design — it must never be collected into an automated run.
+  // See playwright.playground.config.ts / `npm run playtest`.
+  testIgnore: '**/playground.spec.ts',
   timeout: 60_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,

--- a/Treachery/playwright.playground.config.ts
+++ b/Treachery/playwright.playground.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Config for the manual playtest harness (e2e/playground.spec.ts) — driven by
+ * `npm run playtest`, never by CI.
+ *
+ * Differs from playwright.config.ts in the ways that matter for driving a game
+ * by hand rather than asserting on one: windows are visible, there is no test
+ * timeout (you decide when you're done), and the viewport is small enough that
+ * four to eight windows tile on a laptop screen.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/playground.spec.ts',
+  // No timeout: the spec parks on page.pause() until you dismiss it.
+  timeout: 0,
+  // Individual assertions during setup should still fail fast rather than hang.
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:8082',
+    headless: false,
+    viewport: { width: 820, height: 900 },
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npx serve dist -p 8082 -s --no-clipboard',
+    url: 'http://localhost:8082',
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+});


### PR DESCRIPTION
Testing a game by hand meant opening four browsers and signing into each one. The E2E harness already spawns one authenticated context per player and walks them into a started game — it just did it for assertions. This exposes the same bootstrap for driving by hand.

```bash
npm run playtest
```

Opens one real signed-in window per player, prints the roster, and parks so every window stays interactive:

```
┌──────────────────────────────────────────────┐
│ game code   2WPQ                             │
│ mode        treachery                        │
│ players     4                                │
│                                              │
│ Player 1   leader (leader_01)                │
│ Player 2   assassin (assassin_01)            │
│ Player 3   assassin (assassin_02)            │
│ Player 4   traitor (traitor_01)              │
│                                              │
│ All windows are signed in and live.          │
└──────────────────────────────────────────────┘
```

### Knobs

| Env var | Values | Default |
|---|---|---|
| `PLAYTEST_PLAYERS` | 4–8 | 4 |
| `PLAYTEST_MODE` | `treachery` / `treachery_planechase` / `planechase` / `none` | `treachery` |
| `PLAYTEST_LIFE` | multiple of 5 | 40 |
| `PLAYTEST_START` | `seeded` / `real` / `lobby` | `seeded` |

`seeded` deals deterministically so player 1 is always the Leader and you know where to look. `real` goes through the Start button for genuine random assignment. **`lobby`** stops before the start — that's the one for exercising lobby settings (max players, starting life, game mode, max traitor rarity) with a full table already seated.

`npm run playtest:nobuild` skips the web rebuild (~30s) when `dist/` is already an emulator build.

### Safety
The spec never terminates by design, so collecting it into an automated run would hang the job. It's excluded via `testIgnore` in `playwright.config.ts`. Verified both directions: the CI config collects **0** playground specs, the playground config collects exactly **1**.

Runs against the emulator, so games are disposable and no real accounts or data are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)