### PR TITLE
Document the current state of the project

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,12 @@
 # Treachery iOS - Implementation Plan
 
+> **Historical document** (March 2026). This was the original iOS-only build
+> plan; the project has since grown into a monorepo with web and Android
+> clients, server-side game logic in Cloud Functions, Planechase/Life Tracker
+> modes, ELO, and a four-layer test harness. For the current state of the
+> project see the [README](README.md) and [docs/](docs/). Kept for the
+> Firestore schema reference and as a record of the original design.
+
 ## Overview
 Build a full remote-multiplayer Treachery companion app with real-time game state sync,
 identity cards with unveil abilities, game code + friends-based joining.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,14 @@ Each player also receives a secret **Identity Card** with a unique unveil abilit
 - **Life tracking** — Tap +/- to adjust any player's life total, synced in real-time with optimistic updates
 - **Role & identity assignment** — Automatic role distribution and identity card dealing based on player count
 - **Unveil mechanic** — One-time reveal of your identity to activate your card's ability
+- **Traitor abilities** — Server-resolved unveil effects for the Metamorph, Puppet Master, and Wearer of Masks
 - **Elimination & win detection** — Automatic win condition checking when players are eliminated
 - **62 identity cards** — 13 Leaders, 18 Guardians, 18 Assassins, 13 Traitors
+- **Game settings** — Max players, starting life, game mode, and a max traitor rarity cap for the random pool (rarity selector currently web-only; the backend supports all clients)
+- **Planechase mode** — Shared planar deck, die rolls with chaos/planeswalk resolution, phenomena — playable standalone or combined with Treachery
+- **Life Tracker mode** — Plain multiplayer life tracking for regular Commander games
+- **ELO & deck stats** — Per-player and per-commander ratings updated when games finish
+- **Push notifications** — Joins, game start, eliminations, and planeswalks via FCM
 - **Friends system** — Add friends and invite them to games
 - **Game history** — View past games and results
 - **Multiple auth methods** — Email/password, phone number, or guest sign-in
@@ -86,10 +92,14 @@ Each player also receives a secret **Identity Card** with a unique unveil abilit
 │       └── data/        # Firebase repositories & DI
 ├── Treachery/           # Web app (Expo/React Native)
 │   ├── app/             # File-based routes
-│   └── src/             # Components, hooks, services, models
-├── functions/           # Firebase Cloud Functions
+│   ├── src/             # Components, hooks, services, models
+│   └── e2e/             # Playwright suite + simulation harness + playtest tool
+├── functions/           # Firebase Cloud Functions (all game logic)
+│   └── test/            # Unit suite + integration suite vs. real callables
+├── firestore-tests/     # Security-rules test suite (rules-unit-testing)
+├── docs/                # TESTING, DEPLOYMENT, KNOWN-ISSUES
 ├── firebase.json        # Firebase project config
-└── firestore.rules      # Firestore security rules
+└── firestore.rules      # Firestore security rules (source of truth — never edit in console)
 ```
 
 ## Getting Started
@@ -118,20 +128,35 @@ npm install
 npx expo start --web
 ```
 
-### Cloud Functions
+## Testing
+
+Four automated layers run on every PR — functions unit + integration
+(against the real callables), Firestore security rules, and a Playwright E2E
+suite that includes a seeded multi-player simulation/fuzz harness. Known bugs
+are tracked as *skipped tests asserting the correct behaviour*, so the suites
+double as an executable backlog.
+
 ```bash
-cd functions
-npm install
-firebase deploy --only functions
+cd functions && npm test                  # unit (~2s)
+cd functions && npm run test:integration  # real callables vs emulator (~70s)
+cd firestore-tests && npm test            # security rules (~3s)
+cd Treachery && npm run test:e2e          # browsers + simulation (~2min, needs Java 21+)
 ```
 
-### Deploy Web to Firebase Hosting
-```bash
-cd Treachery
-npx expo export --platform web
-cd ..
-firebase deploy --only hosting
-```
+To playtest by hand without opening four browsers, `cd Treachery && npm run
+playtest` opens one signed-in window per player already seated in a game.
+
+Details, fuzzing knobs, and the skip convention: [docs/TESTING.md](docs/TESTING.md)
+
+## Deployment
+
+Push to `main` auto-deploys the **staging** web app plus the *shared*
+functions/rules; publishing a GitHub release promotes to production (web +
+App Store + Play). Staging and production share one Firebase project, so
+backend changes reach production users immediately — the full pipeline map
+and its implications: [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)
+
+Current bug backlog and audit findings: [docs/KNOWN-ISSUES.md](docs/KNOWN-ISSUES.md)
 
 ## Game Flow
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,76 @@
+# Deployment & Environments
+
+## The one thing to internalize first
+
+**Staging and production share a single Firebase project** (`treachery-71922`).
+Only *web hosting* is split into two sites; Firestore, Cloud Functions, and
+security rules are shared. Consequences:
+
+- A functions or rules change "deployed to staging" is **live for production
+  users immediately**. Functions changes must be backward-compatible (new game
+  fields optional, absent = old behaviour); rules changes get no staging
+  rehearsal, so review them against the `firestore-tests/` suite before merge.
+- The staging *web app* is the only truly isolated surface — it's the place to
+  test client changes against real Firebase before cutting a release.
+
+| Environment | URL | Updated by |
+|---|---|---|
+| Production web | [treachery.games](https://treachery.games) | Publishing a GitHub release |
+| Staging web | [treachery-staging.web.app](https://treachery-staging.web.app) | Push to `main` |
+| Functions / rules / Firestore (shared) | — | Push to `main` |
+| iOS TestFlight | — | Push to `main` touching `Treachery-iOS/**` |
+| iOS App Store | — | Publishing a GitHub release |
+| Android Play internal | — | Push to `main` touching `TreacheryAndroid/**` |
+| Android Play production | — | Publishing a GitHub release |
+
+## Workflows (`.github/workflows/`)
+
+| Workflow | Trigger | Deploys |
+|---|---|---|
+| `ci.yml` | PR to `main` | nothing — gates the merge (web typecheck/lint/build, functions unit + integration, rules suite, Playwright E2E) |
+| `deploy-staging.yml` | push to `main` touching `Treachery/**`, `functions/**`, `firebase.json`, `firestore.rules`, `firestore.indexes.json` | staging hosting + **shared** functions, rules, indexes |
+| `deploy-web-production.yml` | release published | production hosting + functions |
+| `deploy-testflight.yml` | push to `main` touching `Treachery-iOS/**` | TestFlight |
+| `deploy-internal-test.yml` | push to `main` touching `TreacheryAndroid/**` | Play internal test |
+| `deploy-appstore.yml` / `deploy-playstore.yml` | release published | store production |
+
+Practical implications of the path filters:
+
+- A PR touching only web + functions rolls out to staging on merge and
+  triggers **no** native pipelines. This is the standard "staging first" path.
+- Touching `Treachery-iOS/**` or `TreacheryAndroid/**` ships builds to
+  TestFlight / Play internal on merge — keep native changes out of a PR meant
+  for staging-only rollout.
+- Docs, tests, and workflow files trigger no deploys.
+
+## Promoting to production
+
+Publish a GitHub release. That single event fans out to production web
+hosting, App Store submission, and Play production. There is no partial
+promote — cut the release when *all three* clients are ready for what's on
+`main`.
+
+## Rules changes
+
+`firestore.rules` in the repo is the source of truth. **Never edit rules in
+the Firebase console** — the next deploy from `main` silently overwrites
+console edits. The change loop:
+
+1. Edit `firestore.rules`
+2. Un-skip the matching test(s) in `firestore-tests/test/` and
+   `cd firestore-tests && npm test` (~3s)
+3. Merge — the staging workflow deploys rules to the shared project
+
+## Local development
+
+```bash
+# Web app against local emulators (auth, firestore, functions):
+cd Treachery
+npm run web            # expo dev server; set EXPO_PUBLIC_USE_EMULATOR=true
+
+# Or a full emulator-backed built app + 4 signed-in players:
+npm run playtest       # see docs/TESTING.md
+```
+
+Manual deploys (`firebase deploy ...`) work as a fallback but the workflows
+are the normal path; prefer merging to `main` so CI gates the change.

--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -1,0 +1,81 @@
+# Known Issues
+
+Findings from the July 2026 full-codebase audit (six independent review passes
+over the web app, Cloud Functions, and Firestore rules, each finding verified
+against source — and where marked *reproduced*, against a running emulator).
+
+Most entries are **encoded as skipped tests** that assert the correct
+behaviour — see the skip convention in [TESTING.md](TESTING.md). Fixing one
+means flipping its marker; the suites below are the authoritative, executable
+version of this list. This file is the human-readable index.
+
+Status values: **open**, **fix in review** (PR open), **fixed** (merged —
+entries move here then get pruned).
+
+## Security / privacy (Firestore rules)
+
+Reachable by any signed-in user — including anonymous guests — via direct SDK
+writes. Encoded in `firestore-tests/`.
+
+| Issue | Status |
+|---|---|
+| Every user doc world-readable: `email`, `phone_number`, `fcm_token` exposed to any signed-in user. Needs PII split into an owner-only subcollection — rules cannot withhold individual fields | **open** |
+| Non-participants can inject themselves into `player_ids` of an `in_progress` game, then read every player's hidden role/identity | **fix in review — #97** |
+| `player_ids` can be overwritten wholesale (evict the whole table) | **fix in review — #97** |
+| Join rule enforces no `max_players` capacity | **fix in review — #97** |
+| Player docs creatable in any game with attacker-chosen `life_total`/`order_id` (rules have no state/membership/capacity check). Needs the host's own client-side create moved server-side before the rule can be denied | **open** |
+| A victim's `friend_ids` can be wiped by overwrite | **fix in review — #97** |
+| A one-sided friendship can be forced without an accepted request (residual after #97 — rules can't verify a request exists; needs accept/remove moved into a callable) | **open** |
+
+## Critical gameplay (Cloud Functions)
+
+Encoded in `functions/test/integration/callables/`.
+
+| Issue | Status |
+|---|---|
+| Non-treachery games (Planechase / Life Tracker) auto-finish the moment any player hits 0 life — `checkWinConditions` has no game-mode guard and credits "assassin" on the null-roles fallthrough. *Reproduced* | **open** |
+| `updateGameSettings` starting-life change **always throws** (read-after-write inside its transaction) and rolls back co-submitted settings. *Reproduced* | **open** |
+| `resolvePuppetMaster` accepts any card id for any player — no permutation check, no elimination check, no once-per-game guard; can mint a second Leader or hand a team the win. *Reproduced* | **open** |
+| `resolveMetamorph` never clears the stolen card from its target → duplicate identities in play; no elimination/once-only guard. *Reproduced* | **open** |
+| `resolveWearerOfMasks` allows copying `traitor_09`, inheriting Puppet Master powers | **open** |
+| `leaveGame` doesn't renumber seats; next join reuses a live `order_id`, making every `orderBy("order_id")` read non-deterministic (seating, host promotion, win tally). *Reproduced: `0, 2, 2`* | **open** |
+| `onGameFinished` interpolates user-controlled `commander_name` into a Firestore field path (`deck_stats.${name}`): dots silently fragment stats; `/ ~ * [ ]` throw and abort the **whole game's** ELO batch | **open** |
+
+## High-impact UI (web)
+
+Encoded in `Treachery/e2e/` (`test.fixme`) and `KNOWN_BROKEN_INVARIANTS`.
+
+| Issue | Status |
+|---|---|
+| Game-over screen reveals every hidden identity and is reachable mid-game (eliminated spectator "Leave Game", forfeit, or direct `/game-over/<id>` URL) | **open** |
+| Server-promoted host can't start the game — lobby freezes `isHost` from a navigation param instead of reading `game.host_id` | **open** |
+| Near-simultaneous life adjustments silently drop taps (optimistic-delta clearing races the snapshot) | **open** |
+| Planechase phenomena unreachable: `resolvePhenomenon` has no UI caller, so Interplanar Tunnel / Spatial Merging / Chaotic Aether park the table | **open** |
+| Puppet Master resolver sheet shows all players' hidden cards before redistribution | **open** |
+| `canSeeRole` is a dead prop in `PlayerRow` — the Puppet Master face-down peek never renders | **open** |
+| `Alert.alert` is a no-op on react-native-web: forgot-password confirmation and lobby "Copied!" never show; forgot-password also reads a stale error closure and reports success on failure | **open** |
+
+## Lower severity
+
+Not all individually test-encoded; from the audit report.
+
+- Profile win-rate deflated (divides by games with no recorded winner)
+- `max_players` mismatch: create screen writes 12 for non-treachery, settings/server cap at 8, bricking the stepper for those games
+- Planar die cost displays the previous roller's count, not the caller's actual (often free) cost
+- Stale/deleted game link → infinite spinner with the web back button trapped
+- Client-side game-code generation is check-then-act racy; duplicate codes make one game unjoinable by code
+- New-user onboarding skippable via a `createUserDocumentIfNeeded` double-invocation race
+- `useConnectionStatus` watches only `navigator.onLine`, never Firestore sync state
+- Wearer of Masks X-cost unenforced server-side
+- Passwords trimmed before length validation
+- Duplicate friend requests after reload (sent-set is session-only)
+- N+1 sequential player fetches in history/profile
+- `getRoleDistribution` falls back to a sum-4 distribution for 9+ players (latent — reachable only via the rules capacity bypass)
+
+## Repo hygiene
+
+- `functions/node_modules` is committed (~6.9k tracked files), inflating every
+  diff and causing spurious conflicts. Untrack with
+  `git rm -r --cached functions/node_modules` (safe: all workflows `npm ci`)
+- Lobby "Game Mode" chips clip off-screen at phone widths ("Treachery +
+  Planechase" unreachable at 375px)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,82 @@
+# Testing
+
+The repo has four automated test layers plus a manual playtest harness. Each
+layer exists because the one above it structurally *cannot* catch a class of
+bug — that reasoning is worth keeping in mind when deciding where a new test
+belongs.
+
+| Layer | Where | Command | Speed | Catches what nothing else can |
+|---|---|---|---|---|
+| Functions unit | `functions/test/game-logic.test.js` | `cd functions && npm test` | ~2s | Pure logic regressions (fast feedback) |
+| Functions integration | `functions/test/integration/callables/` | `cd functions && npm run test:integration` | ~70s | Bugs in the **real** exported callables — the unit suite re-implements the logic it checks, so it validates a copy |
+| Firestore rules | `firestore-tests/` | `cd firestore-tests && npm test` | ~3s | Security-rule holes. The Playwright suite drives the UI, which only takes legitimate paths, so a rule permitting a hostile direct SDK write is invisible to it |
+| Web E2E + simulation | `Treachery/e2e/` | `cd Treachery && npm run test:e2e` | ~2min | Full-stack behaviour through real browsers, plus randomized multi-player play |
+
+All four run on every PR (`.github/workflows/ci.yml`). The emulator-backed
+suites need **Java 21+** — the rules and integration runners auto-detect a JDK,
+but `test:e2e` does not:
+
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk@23/libexec/openjdk.jdk/Contents/Home
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+## The skip convention: tests as an executable bug list
+
+Tests for **known, currently-unfixed bugs** are written asserting the *correct*
+behaviour and then marked skipped:
+
+- mocha suites: `it.skip` with a `// SKIP: ...` comment naming the finding
+- Playwright: `test.fixme` with a `// FIXME: ...` comment
+- the simulation harness: flags in `KNOWN_BROKEN_INVARIANTS`
+  (`Treachery/e2e/simulation/invariants.ts`)
+
+Fixing a bug means flipping one marker; the test needs no rewrite, and the
+skip list doubles as the canonical bug backlog (see
+[KNOWN-ISSUES.md](KNOWN-ISSUES.md)). Never write a test that asserts buggy
+behaviour is correct, and never delete a skipped test because it fails when
+enabled — failing-when-enabled is the point.
+
+Every skip was verified non-vacuous by un-skipping and re-running: exactly the
+expected set fails.
+
+## The simulation harness (fuzzer)
+
+`Treachery/e2e/simulation.spec.ts` drives 4–8 real browser contexts making
+semi-random *legal* moves, asserting invariants after every action (card
+uniqueness, role-follows-card, life arithmetic, one-way elimination, state
+monotonicity, winner consistency). CI runs a small pinned-seed set; locally it
+becomes a real fuzzer:
+
+```bash
+SIM_SEED=random SIM_STEPS=60 SIM_REPEAT=25 npm run test:e2e -- simulation
+```
+
+Failures print the seed and move list; replay with `SIM_SEED=<seed>`. If you
+fix a bug listed in `KNOWN_BROKEN_INVARIANTS`, flip its flag to `false` so the
+fuzzer starts enforcing that invariant again.
+
+## Manual playtesting
+
+```bash
+cd Treachery && npm run playtest
+```
+
+Opens one real signed-in browser window per player, already in a started game
+(against the local emulator — disposable, no real data), prints who holds
+which role, and stays interactive until you dismiss the Playwright Inspector.
+Knobs: `PLAYTEST_PLAYERS` (4–8), `PLAYTEST_MODE`
+(`treachery`/`treachery_planechase`/`planechase`/`none`), `PLAYTEST_LIFE`,
+`PLAYTEST_START` (`seeded` = deterministic, player 1 is the Leader; `real` =
+the actual Start button; `lobby` = stop before starting — the one for testing
+lobby settings with a full table). `npm run playtest:nobuild` skips the ~30s
+web rebuild if `dist/` is already an emulator build.
+
+## Known flake
+
+Under heavy machine load, concurrent lobby joins can exceed even the 20s
+assertion window in `guestJoinGame` — every `joinGame` call transacts on the
+same game doc, so they serialize (~9.5s worst observed for an 8-player join,
+with zero function errors). CI's `retries: 1` absorbs it. If it recurs
+locally, check what else the machine is doing before suspecting your change;
+a quiet-machine rerun has settled it every time so far.


### PR DESCRIPTION
The README predated the test harness, the deploy pipelines, and most of the features that now exist; PLAN.md described an iOS-only app with client-side game logic. This brings the documentation up to reality.

- **README** — feature list now covers Planechase, Life Tracker, ELO, push notifications, and game settings (including the max-traitor-rarity cap); project structure includes the three test suites and `docs/`; manual firebase-deploy instructions replaced with the actual CI/CD flows plus a testing quickstart.
- **docs/TESTING.md** — the four test layers and *why each exists* (what the layer above it structurally cannot catch), the skipped-test-as-executable-bug-list convention, simulation fuzzing knobs, the manual playtest harness, the Java 21 requirement, and the known join-contention flake.
- **docs/DEPLOYMENT.md** — environment map, workflow triggers with their path filters, and the load-bearing caveat: staging and production share one Firebase project, so functions/rules changes reach production users on merge.
- **docs/KNOWN-ISSUES.md** — the July 2026 audit backlog with severity and status, as the human-readable index over the skipped tests.
- **PLAN.md** — marked as the historical March 2026 design document it is, kept for the schema reference.

Docs are written to describe mechanisms rather than counts wherever possible, so they don't rot as skips get un-skipped.

Note: assumes #98 (playtest harness) lands first — the testing docs reference `npm run playtest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)