### PR TITLE
Replace native confirm popovers with an in-app ConfirmDialog

### DIFF
--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -27,6 +27,7 @@ import { ErrorBanner } from '@/components/ErrorBanner';
 import { LoadingScreen } from '@/components/LoadingScreen';
 import { ConnectionBanner } from '@/components/ConnectionBanner';
 import { AbilityResolver, shouldShowAbilityResolver } from '@/components/AbilityResolver';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { ROLE_DISPLAY_NAMES } from '@/constants/roles';
 import { Player } from '@/models/types';
 import { colors, spacing, fonts } from '@/constants/theme';
@@ -139,47 +140,43 @@ export default function GameBoardScreen() {
     });
   };
 
-  const handleForfeit = () => {
-    if (Platform.OS === 'web') {
-      const confirmed = window.confirm(
-        'Forfeit Game?\n\nYou will be eliminated from the game. This cannot be undone.',
-      );
-      if (confirmed) {
-        eliminateAndLeave().then(navigateToGameOver);
-      }
-    } else {
-      Alert.alert('Forfeit Game?', 'You will be eliminated from the game. This cannot be undone.', [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Forfeit',
-          style: 'destructive',
-          onPress: async () => {
-            await eliminateAndLeave();
-            navigateToGameOver();
-          },
-        },
-      ]);
-    }
-  };
+  // Which confirmation (if any) is showing. In-app ConfirmDialog instead of
+  // window.confirm/Alert.alert: one themed code path on every platform, and
+  // it stays clickable under automation (Playwright silently cancels native
+  // dialogs, which made these buttons appear dead in the playtest harness).
+  const [pendingConfirm, setPendingConfirm] = useState<'unveil' | 'forfeit' | null>(null);
 
-  const handleUnveil = () => {
+  const handleForfeit = () => setPendingConfirm('forfeit');
+  const handleUnveil = () => setPendingConfirm('unveil');
+
+  const confirmDialogProps = () => {
+    if (pendingConfirm === 'forfeit') {
+      return {
+        title: 'Forfeit Game?',
+        message: 'You will be eliminated from the game. This cannot be undone.',
+        confirmLabel: 'Forfeit',
+        confirmAccessibilityLabel: 'Confirm forfeit',
+        destructive: true,
+        onConfirm: async () => {
+          setPendingConfirm(null);
+          await eliminateAndLeave();
+          navigateToGameOver();
+        },
+      };
+    }
     const roleName = currentPlayer?.role ? ROLE_DISPLAY_NAMES[currentPlayer.role] : '';
     const cardName = currentIdentityCard?.name ?? '';
-    if (Platform.OS === 'web') {
-      const confirmed = window.confirm(
-        `Unveil your identity?\n\nThis will reveal your role (${roleName}) and card (${cardName}) to all players. This cannot be undone.`,
-      );
-      if (confirmed) unveilCurrentPlayer();
-    } else {
-      Alert.alert(
-        'Unveil your identity?',
-        `This will reveal your role (${roleName}) and card (${cardName}) to all players. This cannot be undone.`,
-        [
-          { text: 'Cancel', style: 'cancel' },
-          { text: 'Unveil', onPress: () => unveilCurrentPlayer() },
-        ],
-      );
-    }
+    return {
+      title: 'Unveil your identity?',
+      message: `This will reveal your role (${roleName}) and card (${cardName}) to all players. This cannot be undone.`,
+      confirmLabel: 'Unveil',
+      confirmAccessibilityLabel: 'Confirm unveil',
+      destructive: false,
+      onConfirm: () => {
+        setPendingConfirm(null);
+        unveilCurrentPlayer();
+      },
+    };
   };
 
   const handleEndGame = () => {
@@ -610,6 +607,8 @@ export default function GameBoardScreen() {
           </View>
         </View>
       </Modal>
+
+      <ConfirmDialog visible={pendingConfirm !== null} {...confirmDialogProps()} onCancel={() => setPendingConfirm(null)} />
     </View>
   );
 }

--- a/Treachery/app/(app)/lobby/[gameId].tsx
+++ b/Treachery/app/(app)/lobby/[gameId].tsx
@@ -18,6 +18,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { useAuth } from '@/hooks/useAuth';
 import { useLobby } from '@/hooks/useLobby';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { LoadingScreen } from '@/components/LoadingScreen';
 import { ConnectionBanner } from '@/components/ConnectionBanner';
@@ -266,8 +267,13 @@ export default function LobbyScreen() {
   };
 
   const [isLeaving, setIsLeaving] = useState(false);
+  // In-app ConfirmDialog instead of window.confirm/Alert.alert — one themed
+  // code path on every platform, and clickable under automation (Playwright
+  // silently cancels native dialogs).
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 
   const doLeave = async () => {
+    setShowLeaveConfirm(false);
     setIsLeaving(true);
     if (currentUserId) {
       await leaveGame(currentUserId);
@@ -275,22 +281,7 @@ export default function LobbyScreen() {
     router.replace('/(app)');
   };
 
-  const handleLeave = () => {
-    if (Platform.OS === 'web') {
-      if (window.confirm('Are you sure you want to leave?')) {
-        doLeave();
-      }
-    } else {
-      Alert.alert('Leave Game', 'Are you sure you want to leave?', [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Leave',
-          style: 'destructive',
-          onPress: doLeave,
-        },
-      ]);
-    }
-  };
+  const handleLeave = () => setShowLeaveConfirm(true);
 
   if (!game && !errorMessage && !isGameDisbanded) {
     return <LoadingScreen message="Loading lobby..." />;
@@ -540,6 +531,17 @@ export default function LobbyScreen() {
           )}
         </TouchableOpacity>
       </View>
+
+      <ConfirmDialog
+        visible={showLeaveConfirm}
+        title="Leave Game"
+        message="Are you sure you want to leave?"
+        confirmLabel="Leave"
+        confirmAccessibilityLabel="Confirm leave"
+        destructive
+        onConfirm={doLeave}
+        onCancel={() => setShowLeaveConfirm(false)}
+      />
     </View>
   );
 }

--- a/Treachery/e2e/helpers.ts
+++ b/Treachery/e2e/helpers.ts
@@ -437,16 +437,16 @@ export async function eliminateByDamage(actor: Page, targetName: string, startin
   await damage(actor, targetName, startingLife);
 }
 
-/** Click Unveil and confirm the window.confirm dialog. */
+/** Click Unveil and accept the in-app confirmation dialog. */
 export async function unveilSelf(page: Page) {
-  page.once('dialog', (d) => d.accept());
   await page.getByRole('button', { name: 'Unveil identity' }).click();
+  await page.getByRole('button', { name: 'Confirm unveil' }).click();
 }
 
-/** Click Forfeit and confirm. */
+/** Click Forfeit and accept the in-app confirmation dialog. */
 export async function forfeit(page: Page) {
-  page.once('dialog', (d) => d.accept());
-  await page.getByRole('button', { name: 'Forfeit' }).click();
+  await page.getByRole('button', { name: 'Forfeit', exact: true }).click();
+  await page.getByRole('button', { name: 'Confirm forfeit' }).click();
 }
 
 /**

--- a/Treachery/e2e/host-promotion.spec.ts
+++ b/Treachery/e2e/host-promotion.spec.ts
@@ -19,9 +19,9 @@ test.describe('Host leaves a lobby with players still in it', () => {
 
     expect((await fetchGameDoc(hostPage, gameId))?.host_id).toBe(userIds[0]);
 
-    // Host leaves (window.confirm on web).
-    hostPage.once('dialog', (d) => d.accept());
+    // Host leaves, accepting the in-app confirmation.
     await hostPage.getByRole('button', { name: 'Leave game' }).click();
+    await hostPage.getByRole('button', { name: 'Confirm leave' }).click();
 
     // The game survives, and host_id moves to the next seat.
     await expect
@@ -54,8 +54,8 @@ test.describe('Host leaves a lobby with players still in it', () => {
     const { pages, userIds, gameId } = await setupLobby(browser, 3);
     const [hostPage, secondPage, thirdPage] = pages;
 
-    hostPage.once('dialog', (d) => d.accept());
     await hostPage.getByRole('button', { name: 'Leave game' }).click();
+    await hostPage.getByRole('button', { name: 'Confirm leave' }).click();
 
     await expect
       .poll(async () => (await fetchGameDoc(secondPage, gameId))?.host_id, { timeout: 15_000 })

--- a/Treachery/src/components/ConfirmDialog.tsx
+++ b/Treachery/src/components/ConfirmDialog.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors, fonts, spacing } from '@/constants/theme';
+
+/**
+ * In-app confirmation dialog, replacing window.confirm / Alert.alert forks.
+ *
+ * Why not the native ones: window.confirm renders outside the app (unthemed,
+ * blocks the JS thread, and automation layers like Playwright auto-dismiss it
+ * unless specially handled — in the playtest harness that made Unveil appear
+ * to do nothing), and RN-web compiles Alert.alert to a silent no-op. One
+ * component, one code path, every platform.
+ *
+ * The confirm button gets a DISTINCT accessibility label (e.g. "Confirm
+ * unveil") so tests and screen readers can't collide with the button that
+ * opened the dialog ("Unveil identity" vs "Unveil").
+ */
+export interface ConfirmDialogProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  /** Text shown on the confirm button (e.g. "Unveil"). */
+  confirmLabel: string;
+  /** Accessibility label for the confirm button (e.g. "Confirm unveil"). */
+  confirmAccessibilityLabel: string;
+  /** Styles the confirm button red for irreversible/negative actions. */
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  visible,
+  title,
+  message,
+  confirmLabel,
+  confirmAccessibilityLabel,
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <View style={styles.backdrop}>
+        {/* Backdrop tap cancels — same affordance as dismissing a native sheet */}
+        <TouchableOpacity
+          style={StyleSheet.absoluteFill}
+          onPress={onCancel}
+          accessibilityLabel="Dismiss dialog"
+        />
+        <View style={styles.card}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.message}>{message}</Text>
+          <View style={styles.buttonRow}>
+            <TouchableOpacity
+              style={styles.cancelButton}
+              onPress={onCancel}
+              accessibilityLabel="Cancel"
+              accessibilityRole="button"
+            >
+              <Text style={styles.cancelText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.confirmButton, destructive && styles.confirmButtonDestructive]}
+              onPress={onConfirm}
+              accessibilityLabel={confirmAccessibilityLabel}
+              accessibilityRole="button"
+            >
+              <Text
+                style={[styles.confirmText, destructive && styles.confirmTextDestructive]}
+              >
+                {confirmLabel}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.lg,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 400,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.borderAccent,
+    borderRadius: 12,
+    padding: spacing.lg,
+    gap: 10,
+  },
+  title: {
+    color: colors.text,
+    fontSize: 18,
+    fontWeight: 'bold',
+    fontFamily: fonts.serif,
+  },
+  message: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+    marginTop: 6,
+  },
+  cancelButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  cancelText: {
+    color: colors.textSecondary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  confirmButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: colors.primary,
+  },
+  confirmButtonDestructive: {
+    backgroundColor: colors.destructive,
+  },
+  confirmText: {
+    color: '#0d0b1a',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  confirmTextDestructive: {
+    color: colors.text,
+  },
+});


### PR DESCRIPTION
Requested after playtesting: the unveil confirmation was a native `window.confirm`, which automation layers auto-dismiss (Playwright answers "Cancel" before it renders — the button looked dead in the playtest harness) and which renders as unthemed browser chrome for real users.

### What changed
`ConfirmDialog` — a themed RN `Modal` rendered inside the app window on every platform — replaces all three native-confirm forks:

| Action | Before | Now |
|---|---|---|
| Unveil (game board) | `window.confirm` / `Alert.alert` fork | in-app dialog, gold confirm |
| Forfeit (game board) | same fork | in-app dialog, destructive red confirm |
| Leave (lobby) | same fork | in-app dialog, destructive red confirm |

Design details worth reviewing:
- Confirm buttons carry **distinct accessibility labels** (`Confirm unveil` etc.) so tests/screen readers can't collide with the buttons that opened the dialog ("Unveil identity" vs "Unveil" are substring-ambiguous otherwise).
- Backdrop tap cancels. One code path — the `Platform.OS` forks are gone. This also removes the last places relying on `Alert.alert` for *confirmation* (RN-web compiles it to a silent no-op — the audit's finding #14 family).

### E2E
`unveilSelf`/`forfeit` helpers and the host-promotion leave flows click the in-app buttons instead of registering `page.once('dialog')` handlers. Full suite green: **31 passed / 8 skipped** — every win-matrix, ability, and simulation flow exercises the new dialog. Also hands-on verified in a browser: opaque themed card, cancel keeps you seated, confirm leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)