### PR TITLE
Add the desktop Round Table board with drag-to-reorder and turn tracking

### DIFF
--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -88,6 +88,31 @@ export default function GameBoardScreen() {
   const isHost = game?.host_id === currentUserId;
   const canResolveAbility = shouldShowAbilityResolver(currentPlayer);
 
+  /**
+   * Whether a player's role may be shown on the board roster.
+   *
+   * useGameBoard's canSeeRole() reports true for your OWN player, which is
+   * fine for "do I know this role" but wrong for the roster: your identity
+   * lives in the header card, and the roster deliberately conceals it (the
+   * mobile PlayerRow has always done this). Showing it in both places is
+   * redundant, and it makes the board disagree with the concealment model
+   * the visibility specs enforce.
+   *
+   * Leaders stay public — that is a rule of the game — and canSeeRole still
+   * governs everyone else, so the Puppet Master's face-down peek keeps
+   * working.
+   */
+  const mayRevealRole = (player: Player) => {
+    if (!isTreacheryActive) return false;
+    if (player.role === 'leader') return true;
+    // Once unveiled the role is public to the whole table, including on your
+    // own tile — unveiling is exactly the act of making it public.
+    if (player.is_unveiled && !player.is_face_down) return true;
+    // Still concealed: your own role stays in the header, off the roster.
+    if (player.user_id === currentUserId) return false;
+    return canSeeRole(player);
+  };
+
   // Auto-open the ability resolver the first time the current player flips to
   // unveiled while holding one of the three traitor cards that need a follow-up.
   useEffect(() => {
@@ -413,7 +438,7 @@ export default function GameBoardScreen() {
                   player={item}
                   isCurrentUser={item.user_id === currentUserId}
                   isActiveTurn={state.isActiveTurn}
-                  canSeeRole={isTreacheryActive ? canSeeRole(item) : false}
+                  canSeeRole={mayRevealRole(item)}
                   isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
                   onAdjustLife={(amount) => adjustLife(item.id, amount)}
                   onViewCard={() => setInspectedPlayer(item)}

--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -88,31 +88,6 @@ export default function GameBoardScreen() {
   const isHost = game?.host_id === currentUserId;
   const canResolveAbility = shouldShowAbilityResolver(currentPlayer);
 
-  /**
-   * Whether a player's role may be shown on the board roster.
-   *
-   * useGameBoard's canSeeRole() reports true for your OWN player, which is
-   * fine for "do I know this role" but wrong for the roster: your identity
-   * lives in the header card, and the roster deliberately conceals it (the
-   * mobile PlayerRow has always done this). Showing it in both places is
-   * redundant, and it makes the board disagree with the concealment model
-   * the visibility specs enforce.
-   *
-   * Leaders stay public — that is a rule of the game — and canSeeRole still
-   * governs everyone else, so the Puppet Master's face-down peek keeps
-   * working.
-   */
-  const mayRevealRole = (player: Player) => {
-    if (!isTreacheryActive) return false;
-    if (player.role === 'leader') return true;
-    // Once unveiled the role is public to the whole table, including on your
-    // own tile — unveiling is exactly the act of making it public.
-    if (player.is_unveiled && !player.is_face_down) return true;
-    // Still concealed: your own role stays in the header, off the roster.
-    if (player.user_id === currentUserId) return false;
-    return canSeeRole(player);
-  };
-
   // Auto-open the ability resolver the first time the current player flips to
   // unveiled while holding one of the three traitor cards that need a follow-up.
   useEffect(() => {
@@ -438,7 +413,7 @@ export default function GameBoardScreen() {
                   player={item}
                   isCurrentUser={item.user_id === currentUserId}
                   isActiveTurn={state.isActiveTurn}
-                  canSeeRole={mayRevealRole(item)}
+                  canSeeRole={isTreacheryActive ? canSeeRole(item) : false}
                   isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
                   onAdjustLife={(amount) => adjustLife(item.id, amount)}
                   onViewCard={() => setInspectedPlayer(item)}

--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -23,6 +23,8 @@ import { ChaoticAetherBanner } from '@/components/ChaoticAetherBanner';
 import { InterplanarTunnelPicker } from '@/components/InterplanarTunnelPicker';
 import { PhenomenonOverlay } from '@/components/PhenomenonOverlay';
 import { PlayerRow } from '@/components/PlayerRow';
+import { PlayerTile } from '@/components/PlayerTile';
+import { RoundTable } from '@/components/RoundTable';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { LoadingScreen } from '@/components/LoadingScreen';
 import { ConnectionBanner } from '@/components/ConnectionBanner';
@@ -54,6 +56,9 @@ export default function GameBoardScreen() {
     identityCard,
     updatePlayerColor,
     renameCurrentPlayer,
+    activePlayerId,
+    advanceTurn,
+    reorderSeats,
     alivePlayers,
     // Planechase
     isPlanechaseActive,
@@ -381,26 +386,66 @@ export default function GameBoardScreen() {
             <View style={styles.ornateLine} />
           </View>
 
-          {/* Player list */}
-          <FlatList
-            data={players}
-            keyExtractor={(p) => p.id}
-            renderItem={({ item }) => (
-              <PlayerRow
-                player={item}
-                isCurrentUser={item.user_id === currentUserId}
-                canSeeRole={isTreacheryActive ? canSeeRole(item) : false}
-                isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
-                onAdjustLife={(amount) => adjustLife(item.id, amount)}
-                onViewCard={() => setInspectedPlayer(item)}
-                isDisabled={false}
-                onColorChange={item.user_id === currentUserId ? updatePlayerColor : undefined}
-                playerColor={item.player_color}
-                onRename={item.user_id === currentUserId ? renameCurrentPlayer : undefined}
-              />
-            )}
-            style={styles.list}
-          />
+          {/* Player list — desktop gets the Round Table board, mobile keeps
+              the vertical roster it has always had. */}
+          {isDesktop ? (
+            <RoundTable
+              players={players}
+              currentUserId={currentUserId}
+              activePlayerId={activePlayerId}
+              onReorder={reorderSeats}
+              center={
+                <>
+                  <TouchableOpacity
+                    style={styles.turnButton}
+                    onPress={advanceTurn}
+                    accessibilityLabel="Next turn"
+                    accessibilityRole="button"
+                  >
+                    <Ionicons name="play-forward" size={16} color="#0d0b1a" />
+                    <Text style={styles.turnButtonText}>Next Turn</Text>
+                  </TouchableOpacity>
+                  <Text style={styles.tableHint}>Drag a player onto another seat to swap</Text>
+                </>
+              }
+              renderTile={(item, state) => (
+                <PlayerTile
+                  player={item}
+                  isCurrentUser={item.user_id === currentUserId}
+                  isActiveTurn={state.isActiveTurn}
+                  canSeeRole={isTreacheryActive ? canSeeRole(item) : false}
+                  isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
+                  onAdjustLife={(amount) => adjustLife(item.id, amount)}
+                  onViewCard={() => setInspectedPlayer(item)}
+                  onRename={item.user_id === currentUserId ? renameCurrentPlayer : undefined}
+                  onColorChange={item.user_id === currentUserId ? updatePlayerColor : undefined}
+                  playerColor={item.player_color}
+                  isDragging={state.isDragging}
+                  isDropTarget={state.isDropTarget}
+                />
+              )}
+            />
+          ) : (
+            <FlatList
+              data={players}
+              keyExtractor={(p) => p.id}
+              renderItem={({ item }) => (
+                <PlayerRow
+                  player={item}
+                  isCurrentUser={item.user_id === currentUserId}
+                  canSeeRole={isTreacheryActive ? canSeeRole(item) : false}
+                  isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
+                  onAdjustLife={(amount) => adjustLife(item.id, amount)}
+                  onViewCard={() => setInspectedPlayer(item)}
+                  isDisabled={false}
+                  onColorChange={item.user_id === currentUserId ? updatePlayerColor : undefined}
+                  playerColor={item.player_color}
+                  onRename={item.user_id === currentUserId ? renameCurrentPlayer : undefined}
+                />
+              )}
+              style={styles.list}
+            />
+          )}
 
           {errorMessage && <ErrorBanner message={errorMessage} />}
 
@@ -677,6 +722,25 @@ const styles = StyleSheet.create({
   ornateDiamond: {
     color: colors.primary,
     fontSize: 8,
+  },
+  turnButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: colors.primary,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+  },
+  turnButtonText: {
+    color: '#0d0b1a',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  tableHint: {
+    color: colors.textTertiary,
+    fontSize: 11,
+    fontStyle: 'italic',
   },
   list: {
     flex: 1,

--- a/Treachery/e2e/round-table.spec.ts
+++ b/Treachery/e2e/round-table.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect, Page } from '@playwright/test';
+import { fetchGameDoc, fetchPlayerDocs, setupSeededGame } from './helpers';
+
+/**
+ * The desktop Round Table board: seat ring, drag-to-reorder, and the turn
+ * marker.
+ *
+ * These run at a desktop viewport because the board only renders above the
+ * desktop breakpoint — below it the game screen keeps the mobile PlayerRow
+ * list, which the rest of the suite covers.
+ */
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+/** Player doc ids in shared seat order (order_id ascending). */
+async function seatOrder(page: Page, gameId: string): Promise<string[]> {
+  const docs = await fetchPlayerDocs(page, gameId);
+  return docs
+    .slice()
+    .sort((a, b) => (a.order_id ?? 0) - (b.order_id ?? 0))
+    .map((d) => d.id);
+}
+
+/** Centre of a player's tile on the board. */
+async function tileCentre(page: Page, name: string) {
+  const tile = page.getByText(name, { exact: true }).first();
+  await expect(tile).toBeVisible();
+  const box = await tile.boundingBox();
+  if (!box) throw new Error(`No bounding box for ${name}`);
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+test('the board seats every player and marks whose turn it is', async ({ browser }) => {
+  const { players, gameId, host } = await setupSeededGame(browser, [
+    'leader',
+    'assassin',
+    'assassin',
+    'traitor',
+  ]);
+
+  // Every player has a tile.
+  for (const p of players) {
+    await expect(host.page.getByText(p.name, { exact: true }).first()).toBeVisible();
+  }
+
+  // startGame seeds the turn onto the first seat, and the board shows it.
+  const seats = await seatOrder(host.page, gameId);
+  const game = await fetchGameDoc(host.page, gameId);
+  expect(game?.active_player_id).toBe(seats[0]);
+  await expect(host.page.getByText('Turn', { exact: false }).first()).toBeVisible();
+
+  // Advancing moves the marker to the next seat, for everyone.
+  await host.page.getByRole('button', { name: 'Next turn' }).click();
+  await expect
+    .poll(async () => (await fetchGameDoc(host.page, gameId))?.active_player_id, {
+      timeout: 10_000,
+    })
+    .toBe(seats[1]);
+});
+
+test('dragging a player onto another seat swaps them for the whole table', async ({
+  browser,
+}) => {
+  const { players, gameId, host } = await setupSeededGame(browser, [
+    'leader',
+    'assassin',
+    'assassin',
+    'traitor',
+  ]);
+  const observer = players[1];
+
+  const before = await seatOrder(host.page, gameId);
+  expect(before).toHaveLength(4);
+
+  // Drag the tile of one opponent onto another opponent's seat. Real mouse
+  // input with intermediate moves — a single jump does not produce the
+  // pointermove stream a drag needs.
+  const from = await tileCentre(host.page, players[2].name);
+  const to = await tileCentre(host.page, players[3].name);
+
+  await host.page.mouse.move(from.x, from.y);
+  await host.page.mouse.down();
+  await host.page.mouse.move(to.x, to.y, { steps: 24 });
+  await host.page.mouse.up();
+
+  // The seating actually changed on the server...
+  await expect
+    .poll(async () => (await seatOrder(host.page, gameId)).join(','), { timeout: 10_000 })
+    .not.toBe(before.join(','));
+
+  const after = await seatOrder(host.page, gameId);
+  // ...as a SWAP: same members, contiguous seats, exactly two moved.
+  expect(after.slice().sort()).toEqual(before.slice().sort());
+  const moved = after.filter((id, i) => id !== before[i]);
+  expect(moved).toHaveLength(2);
+
+  // ...and another player's client sees the same ring (it is shared state,
+  // not a local view preference).
+  await expect
+    .poll(async () => (await seatOrder(observer.page, gameId)).join(','), { timeout: 10_000 })
+    .toBe(after.join(','));
+});
+
+test('a tap on the life buttons is not treated as a drag', async ({ browser }) => {
+  const { players, gameId, host } = await setupSeededGame(browser, [
+    'leader',
+    'assassin',
+    'assassin',
+    'traitor',
+  ]);
+  const before = await seatOrder(host.page, gameId);
+  const target = players[2];
+
+  await host.page.getByRole('button', { name: `Decrease ${target.name} life` }).click();
+
+  // Life went down...
+  await expect
+    .poll(async () => {
+      const docs = await fetchPlayerDocs(host.page, gameId);
+      return docs.find((d) => d.user_id === target.userId)?.life_total;
+    }, { timeout: 10_000 })
+    .toBeLessThan(40);
+
+  // ...and the seating did not move.
+  expect((await seatOrder(host.page, gameId)).join(',')).toBe(before.join(','));
+});

--- a/Treachery/src/components/PlayerTile.tsx
+++ b/Treachery/src/components/PlayerTile.tsx
@@ -1,0 +1,639 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Pressable,
+  PressableStateCallbackType,
+  ScrollView,
+  StyleSheet,
+  Animated,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Player } from '@/models/types';
+import { ROLE_COLORS, ROLE_DISPLAY_NAMES } from '@/constants/roles';
+import { colors, fonts, PLAYER_COLORS } from '@/constants/theme';
+
+type WebPressableState = PressableStateCallbackType & { hovered?: boolean };
+
+export type PlayerTileSize = 'normal' | 'tv';
+
+/**
+ * Outer size of a seat tile. Fixed on purpose: tiles sit in a ring, so the
+ * container needs to know the box before it can place anything. Exported so the
+ * seat layout can do its maths against the real numbers.
+ */
+export const TILE_WIDTH = 200;
+export const TILE_HEIGHT = 150;
+
+/** Outer size of the 'tv' spectator variant. */
+export const TV_TILE_WIDTH = 300;
+export const TV_TILE_HEIGHT = 220;
+
+/** Height the colour-picker strip animates open to, inside the tile. */
+const PICKER_HEIGHT = 44;
+
+/** Box for a given variant, for containers that render both. */
+export function tileDimensions(size: PlayerTileSize = 'normal'): {
+  width: number;
+  height: number;
+} {
+  return size === 'tv'
+    ? { width: TV_TILE_WIDTH, height: TV_TILE_HEIGHT }
+    : { width: TILE_WIDTH, height: TILE_HEIGHT };
+}
+
+export interface PlayerTileProps {
+  player: Player;
+  isCurrentUser: boolean;
+  /** Highlight ring + badge: it is this player's turn. */
+  isActiveTurn: boolean;
+  /** Whether the viewer may see this player's role. */
+  canSeeRole: boolean;
+  isUnveiledOrLeader: boolean;
+  onAdjustLife: (amount: number) => void;
+  onViewCard?: () => void;
+  /** Own tile only: inline rename (pencil affordance, same UX as PlayerRow's). */
+  onRename?: (name: string) => void;
+  onColorChange?: (color: string | null) => void;
+  playerColor?: string | null;
+  /** Visual state while this tile is being dragged (lifted/shadowed/semi-transparent). */
+  isDragging?: boolean;
+  /** Visual state when a dragged tile would drop here (highlighted outline). */
+  isDropTarget?: boolean;
+  /** 'tv' is a larger variant for a future spectator screen: bigger life number, no controls. */
+  size?: 'normal' | 'tv';
+}
+
+export function PlayerTile({
+  player,
+  isCurrentUser,
+  isActiveTurn,
+  canSeeRole,
+  isUnveiledOrLeader,
+  onAdjustLife,
+  onViewCard,
+  onRename,
+  onColorChange,
+  playerColor,
+  isDragging,
+  isDropTarget,
+  size = 'normal',
+}: PlayerTileProps) {
+  const isTv = size === 'tv';
+
+  // The board already worked out who may see what (own card, the Leader,
+  // anything unveiled face-up, the Puppet Master's peek). The tile trusts that
+  // answer instead of re-deriving a weaker one from the player document.
+  const visibleRole = canSeeRole ? player.role : null;
+  const roleColor = visibleRole ? ROLE_COLORS[visibleRole] : colors.textSecondary;
+  const effectiveColor = player.player_color || playerColor;
+  const canInspectCard = isUnveiledOrLeader && !isCurrentUser && !isTv && !!onViewCard;
+
+  // The tv variant is a read-only spectator screen — no editing your own seat on it.
+  const showOwnControls = isCurrentUser && !isTv;
+
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState(player.display_name);
+  const pickerHeight = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(pickerHeight, {
+      toValue: showColorPicker ? PICKER_HEIGHT : 0,
+      duration: 200,
+      useNativeDriver: false,
+    }).start();
+  }, [showColorPicker, pickerHeight]);
+
+  const submitRename = () => {
+    setIsEditingName(false);
+    const trimmed = nameDraft.trim();
+    if (trimmed && trimmed !== player.display_name) {
+      onRename?.(trimmed);
+    } else {
+      setNameDraft(player.display_name);
+    }
+  };
+
+  const handleColorSelect = (hex: string) => {
+    onColorChange?.(hex);
+    setShowColorPicker(false);
+  };
+
+  const handleClearColor = () => {
+    onColorChange?.(null);
+    setShowColorPicker(false);
+  };
+
+  // Top trim, in ascending precedence — the last thing that applies wins.
+  let trimColor: string = colors.border;
+  if (isCurrentUser) trimColor = colors.primary;
+  if (visibleRole) trimColor = roleColor;
+  if (effectiveColor) trimColor = effectiveColor;
+  if (player.is_eliminated) trimColor = colors.error;
+
+  // Border carries three mutually exclusive states; drop target wins because it
+  // is the only one that answers "what happens if I let go right now?".
+  let borderColor: string = colors.border;
+  if (isCurrentUser) borderColor = 'rgba(201, 168, 76, 0.45)';
+  if (isActiveTurn) borderColor = colors.primary;
+  if (isDropTarget) borderColor = colors.success;
+
+  return (
+    <View
+      style={[
+        styles.tile,
+        isTv && styles.tileTv,
+        isCurrentUser && styles.tileYou,
+        player.is_eliminated && styles.tileEliminated,
+        { borderColor },
+        isDropTarget && styles.tileDropTarget,
+        isDragging && styles.tileDragging,
+      ]}
+    >
+      <View style={[styles.trim, { backgroundColor: trimColor }]} />
+
+      {/* Turn marker: a gold ring AND a worded chip, so the state never rests on
+          colour alone. */}
+      {isActiveTurn && (
+        <View style={styles.turnBadge}>
+          <Ionicons name="caret-forward" size={9} color={colors.primary} />
+          <Text style={styles.turnText}>Turn</Text>
+        </View>
+      )}
+
+      <View style={[styles.head, isActiveTurn && styles.headWithTurnBadge]}>
+        {showOwnControls && onColorChange && (
+          <TouchableOpacity
+            onPress={() => setShowColorPicker(!showColorPicker)}
+            accessibilityLabel="Choose player color"
+            accessibilityRole="button"
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+          >
+            <View
+              style={[
+                styles.colorCircle,
+                effectiveColor ? { backgroundColor: effectiveColor } : styles.colorCircleEmpty,
+              ]}
+            />
+          </TouchableOpacity>
+        )}
+
+        {isEditingName ? (
+          <TextInput
+            style={[styles.name, styles.nameBold, styles.nameInput]}
+            value={nameDraft}
+            onChangeText={setNameDraft}
+            onBlur={submitRename}
+            onSubmitEditing={submitRename}
+            autoFocus
+            maxLength={40}
+            returnKeyType="done"
+            accessibilityLabel="Your name"
+          />
+        ) : (
+          <Text
+            numberOfLines={1}
+            style={[
+              styles.name,
+              isTv && styles.nameTv,
+              isCurrentUser && styles.nameBold,
+              player.is_eliminated && styles.nameEliminated,
+            ]}
+          >
+            {player.display_name}
+          </Text>
+        )}
+
+        {showOwnControls && onRename && !isEditingName && (
+          <TouchableOpacity
+            onPress={() => {
+              setNameDraft(player.display_name);
+              setIsEditingName(true);
+            }}
+            accessibilityLabel="Edit your name"
+            accessibilityRole="button"
+            hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+          >
+            <Ionicons name="pencil" size={13} color={colors.textSecondary} />
+          </TouchableOpacity>
+        )}
+
+        {isCurrentUser && (
+          <View style={styles.youBadge}>
+            <Text style={styles.youText}>You</Text>
+          </View>
+        )}
+
+        {player.is_eliminated && <Ionicons name="close-circle" size={13} color={colors.error} />}
+      </View>
+
+      {player.commander_name ? (
+        <Text numberOfLines={1} style={[styles.commanderName, isTv && styles.commanderNameTv]}>
+          {player.commander_name}
+        </Text>
+      ) : null}
+
+      <View style={styles.lifeRow}>
+        {!player.is_eliminated && !isTv && (
+          <Pressable
+            onPress={() => onAdjustLife(-1)}
+            style={({ hovered, pressed }: WebPressableState) => [
+              styles.lifeButton,
+              hovered && styles.lifeButtonDecrHovered,
+              pressed && styles.lifeButtonPressed,
+            ]}
+            accessibilityLabel={`Decrease ${player.display_name} life`}
+            accessibilityRole="button"
+          >
+            <Ionicons name="remove-circle" size={30} color={colors.error} />
+          </Pressable>
+        )}
+
+        <View style={[styles.lifeBox, isTv && styles.lifeBoxTv]}>
+          <Text
+            style={[
+              styles.lifeText,
+              isTv && styles.lifeTextTv,
+              player.is_eliminated && styles.lifeTextDead,
+            ]}
+          >
+            {player.life_total}
+          </Text>
+        </View>
+
+        {!player.is_eliminated && !isTv && (
+          <Pressable
+            onPress={() => onAdjustLife(1)}
+            style={({ hovered, pressed }: WebPressableState) => [
+              styles.lifeButton,
+              hovered && styles.lifeButtonIncrHovered,
+              pressed && styles.lifeButtonPressed,
+            ]}
+            accessibilityLabel={`Increase ${player.display_name} life`}
+            accessibilityRole="button"
+          >
+            <Ionicons name="add-circle" size={30} color={colors.success} />
+          </Pressable>
+        )}
+      </View>
+
+      {player.is_eliminated ? (
+        <View style={styles.footerRow}>
+          <Ionicons name="skull" size={11} color={colors.error} />
+          <Text style={[styles.eliminatedText, isTv && styles.footerTextTv]}>Eliminated</Text>
+          {visibleRole && (
+            <Text
+              style={[styles.eliminatedRole, isTv && styles.footerTextTv, { color: roleColor }]}
+            >
+              {ROLE_DISPLAY_NAMES[visibleRole]}
+            </Text>
+          )}
+        </View>
+      ) : visibleRole ? (
+        <Pressable
+          onPress={canInspectCard ? onViewCard : undefined}
+          style={({ hovered }: WebPressableState) => [
+            styles.footerRow,
+            styles.roleRow,
+            hovered && canInspectCard && styles.roleRowHovered,
+          ]}
+          disabled={!canInspectCard}
+          accessibilityLabel={`${ROLE_DISPLAY_NAMES[visibleRole]} role${canInspectCard ? ', view card' : ''}`}
+          accessibilityRole="button"
+        >
+          <View
+            style={[styles.roleDot, isTv && styles.roleDotTv, { backgroundColor: roleColor }]}
+          />
+          <Text style={[styles.roleText, isTv && styles.footerTextTv, { color: roleColor }]}>
+            {ROLE_DISPLAY_NAMES[visibleRole]}
+          </Text>
+          {player.is_unveiled && visibleRole !== 'leader' && !isCurrentUser && (
+            <Text style={styles.unveiledText}>(Unveiled)</Text>
+          )}
+          {canInspectCard && (
+            <Ionicons name="information-circle-outline" size={12} color={roleColor} />
+          )}
+        </Pressable>
+      ) : (
+        <View style={styles.footerRow}>
+          <Text style={[styles.hiddenText, isTv && styles.footerTextTv]}>Role Hidden</Text>
+        </View>
+      )}
+
+      {/* Colour picker — overlaid on the tile rather than pushed below it, because
+          the seat ring is laid out against a fixed TILE_HEIGHT. */}
+      {showOwnControls && onColorChange && (
+        <Animated.View style={[styles.colorPicker, { height: pickerHeight }]}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.colorPickerContent}
+          >
+            {PLAYER_COLORS.map((c) => (
+              <TouchableOpacity
+                key={c.hex}
+                onPress={() => handleColorSelect(c.hex)}
+                accessibilityLabel={`Select ${c.name} color`}
+                accessibilityRole="button"
+              >
+                <View
+                  style={[
+                    styles.colorOption,
+                    { backgroundColor: c.hex },
+                    effectiveColor === c.hex && styles.colorOptionSelected,
+                  ]}
+                />
+              </TouchableOpacity>
+            ))}
+            <TouchableOpacity
+              onPress={handleClearColor}
+              accessibilityLabel="Clear color"
+              accessibilityRole="button"
+            >
+              <View style={styles.colorClear}>
+                <Ionicons name="close" size={13} color={colors.textSecondary} />
+              </View>
+            </TouchableOpacity>
+          </ScrollView>
+        </Animated.View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tile: {
+    width: TILE_WIDTH,
+    height: TILE_HEIGHT,
+    backgroundColor: colors.surface,
+    // Always 2px so the active-turn ring is a colour change, not a size change —
+    // a tile that grew on its own turn would shove its neighbours around.
+    borderWidth: 2,
+    borderColor: colors.border,
+    borderRadius: 12,
+    paddingTop: 14,
+    paddingHorizontal: 12,
+    paddingBottom: 10,
+    gap: 4,
+    overflow: 'hidden',
+  },
+  tileTv: {
+    width: TV_TILE_WIDTH,
+    height: TV_TILE_HEIGHT,
+    borderRadius: 16,
+    paddingTop: 18,
+    paddingHorizontal: 18,
+    paddingBottom: 14,
+  },
+  tileYou: {
+    backgroundColor: colors.surfaceLight,
+  },
+  tileEliminated: {
+    opacity: 0.55,
+  },
+  tileDropTarget: {
+    borderStyle: 'dashed',
+    backgroundColor: 'rgba(60, 168, 92, 0.12)',
+  },
+  tileDragging: {
+    opacity: 0.85,
+    transform: [{ scale: 1.04 }],
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.45,
+    shadowRadius: 18,
+  },
+  trim: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 3,
+  },
+  turnBadge: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    backgroundColor: 'rgba(201, 168, 76, 0.2)',
+    borderWidth: 1,
+    borderColor: 'rgba(201, 168, 76, 0.45)',
+    borderRadius: 8,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+  },
+  turnText: {
+    color: colors.primary,
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  head: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headWithTurnBadge: {
+    // Keep the name clear of the absolutely-placed Turn chip.
+    paddingRight: 44,
+  },
+  colorCircle: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+  },
+  colorCircleEmpty: {
+    backgroundColor: colors.surfaceLight,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    borderStyle: 'dashed',
+  },
+  name: {
+    color: colors.text,
+    fontSize: 15,
+    flexShrink: 1,
+  },
+  nameTv: {
+    fontSize: 22,
+  },
+  nameBold: {
+    fontWeight: 'bold',
+  },
+  nameEliminated: {
+    textDecorationLine: 'line-through',
+    color: colors.textSecondary,
+  },
+  nameInput: {
+    // Match the Text metrics so the tile doesn't jump while editing.
+    padding: 0,
+    margin: 0,
+    minWidth: 110,
+  },
+  youBadge: {
+    backgroundColor: 'rgba(201, 168, 76, 0.2)',
+    borderWidth: 1,
+    borderColor: 'rgba(201, 168, 76, 0.3)',
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 10,
+  },
+  youText: {
+    color: colors.primary,
+    fontSize: 10,
+    fontWeight: '600',
+  },
+  commanderName: {
+    fontSize: 11,
+    color: colors.textSecondary,
+    fontStyle: 'italic',
+  },
+  commanderNameTv: {
+    fontSize: 14,
+  },
+  lifeRow: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  lifeBox: {
+    backgroundColor: colors.surfaceLight,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    minWidth: 56,
+    alignItems: 'center',
+  },
+  lifeBoxTv: {
+    minWidth: 130,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+  },
+  lifeText: {
+    color: colors.text,
+    fontSize: 30,
+    // Explicit line height keeps the fixed tile height predictable across platforms.
+    lineHeight: 36,
+    fontWeight: '700',
+    fontFamily: fonts.serif,
+    textAlign: 'center',
+  },
+  lifeTextTv: {
+    fontSize: 68,
+    lineHeight: 78,
+  },
+  lifeTextDead: {
+    color: colors.textTertiary,
+    textDecorationLine: 'line-through',
+  },
+  lifeButton: {
+    borderRadius: 18,
+    padding: 2,
+  },
+  lifeButtonDecrHovered: {
+    backgroundColor: 'rgba(196, 60, 60, 0.15)',
+  },
+  lifeButtonIncrHovered: {
+    backgroundColor: 'rgba(60, 168, 92, 0.15)',
+  },
+  lifeButtonPressed: {
+    opacity: 0.7,
+  },
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    minHeight: 16,
+  },
+  footerTextTv: {
+    fontSize: 16,
+  },
+  roleRow: {
+    borderRadius: 4,
+    paddingVertical: 1,
+    paddingHorizontal: 2,
+    marginHorizontal: -2,
+  },
+  roleRowHovered: {
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+  },
+  roleDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  roleDotTv: {
+    width: 11,
+    height: 11,
+    borderRadius: 6,
+  },
+  roleText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  unveiledText: {
+    fontSize: 9,
+    color: colors.textSecondary,
+    fontStyle: 'italic',
+  },
+  hiddenText: {
+    fontSize: 11,
+    color: colors.textTertiary,
+    fontStyle: 'italic',
+  },
+  eliminatedText: {
+    color: colors.error,
+    fontSize: 11,
+    fontStyle: 'italic',
+  },
+  eliminatedRole: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  colorPicker: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    overflow: 'hidden',
+    backgroundColor: colors.background,
+    borderTopWidth: 1,
+    borderTopColor: colors.divider,
+  },
+  colorPickerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  colorOption: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+  },
+  colorOptionSelected: {
+    borderWidth: 2.5,
+    borderColor: colors.text,
+  },
+  colorClear: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: colors.surfaceLight,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/Treachery/src/components/RoundTable.tsx
+++ b/Treachery/src/components/RoundTable.tsx
@@ -1,0 +1,267 @@
+import React, { useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  LayoutChangeEvent,
+  PanResponder,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { Player } from '@/models/types';
+import { TILE_HEIGHT, TILE_WIDTH } from '@/components/PlayerTile';
+import { rotateToLocalFirst, seatPositions } from '@/components/seatPositions';
+import { colors } from '@/constants/theme';
+
+/**
+ * The desktop "Round Table" board: player tiles arranged around a central
+ * zone, draggable to match where people actually sit.
+ *
+ * Two things are worth knowing about how seating works here.
+ *
+ * The seat RING is shared — it lives in each player's `order_id` on the
+ * server — but every client rotates it so that YOU are always in the bottom
+ * seat (`rotateToLocalFirst`). That mirrors a physical table: everyone agrees
+ * who is on whose left, while each person sees the table from their own
+ * chair. Dragging therefore changes the shared ring, not just your view.
+ *
+ * Dragging uses PanResponder + Animated (core React Native, already the
+ * codebase's animation approach in PlayerRow) rather than gesture-handler or
+ * reanimated: it behaves consistently under react-native-web, where the
+ * gesture libraries are fiddlier, and adds no new dependency.
+ *
+ * A drop SWAPS the dragged tile with the seat it lands on, rather than
+ * splicing the ring. Swapping is what people expect when physically trading
+ * chairs, and it keeps everyone else's position stable — a splice would shift
+ * every downstream seat and make the board lurch.
+ */
+
+export interface RoundTableProps {
+  /** All players, in shared seat order (order_id ascending). */
+  players: Player[];
+  currentUserId: string | null;
+  /** Player doc id whose turn it is, or null. */
+  activePlayerId: string | null;
+  /**
+   * Persist a new seating ring. Receives player doc ids in seat order,
+   * expressed in SHARED order (rotation is undone before this is called).
+   */
+  onReorder: (orderedPlayerIds: string[]) => void;
+  /** Renders one player's tile. `isDragging`/`isDropTarget` drive its visuals. */
+  renderTile: (
+    player: Player,
+    state: { isActiveTurn: boolean; isDragging: boolean; isDropTarget: boolean },
+  ) => React.ReactNode;
+  /** Contents of the middle of the table (plane card, die, status). */
+  center?: React.ReactNode;
+}
+
+export function RoundTable({
+  players,
+  currentUserId,
+  activePlayerId,
+  onReorder,
+  renderTile,
+  center,
+}: RoundTableProps) {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+
+  // Rotated so the local player occupies seat 0 (bottom centre).
+  const seated = useMemo(
+    () => rotateToLocalFirst(players, (p) => p.user_id === currentUserId),
+    [players, currentUserId],
+  );
+  const positions = useMemo(() => seatPositions(seated.length), [seated.length]);
+
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
+  };
+
+  /** Absolute top-left pixel position of a seat, given its centre fraction. */
+  const seatOrigin = (index: number) => {
+    const pos = positions[index] ?? { x: 0.5, y: 0.5 };
+    return {
+      left: pos.x * size.width - TILE_WIDTH / 2,
+      top: pos.y * size.height - TILE_HEIGHT / 2,
+    };
+  };
+
+  return (
+    <View style={styles.container} onLayout={onLayout}>
+      {/* The table itself — a felt ellipse the tiles sit around. */}
+      <View style={styles.tableSurface} pointerEvents="box-none">
+        <View style={styles.tableCenter} pointerEvents="box-none">
+          {center}
+        </View>
+      </View>
+
+      {size.width > 0 &&
+        seated.map((player, index) => (
+          <DraggableSeat
+            key={player.id}
+            index={index}
+            origin={seatOrigin(index)}
+            isDragging={draggingId === player.id}
+            onDragStart={() => {
+              setDraggingId(player.id);
+              setDropTargetId(null);
+            }}
+            onDragMove={(dx, dy) => {
+              // Which seat centre is the tile's centre currently nearest?
+              const from = seatOrigin(index);
+              const cx = from.left + dx + TILE_WIDTH / 2;
+              const cy = from.top + dy + TILE_HEIGHT / 2;
+              // Plain loop rather than forEach: assignments inside a closure
+              // defeat TypeScript's narrowing of `nearestId` below.
+              let nearestId: string | null = null;
+              let nearestDist = Infinity;
+              for (let otherIndex = 0; otherIndex < seated.length; otherIndex++) {
+                if (otherIndex === index) continue;
+                const o = seatOrigin(otherIndex);
+                const dist = Math.hypot(
+                  cx - (o.left + TILE_WIDTH / 2),
+                  cy - (o.top + TILE_HEIGHT / 2),
+                );
+                if (dist < nearestDist) {
+                  nearestDist = dist;
+                  nearestId = seated[otherIndex].id;
+                }
+              }
+              // Only treat it as a drop when meaningfully inside the seat —
+              // otherwise every tiny drag would highlight a neighbour.
+              setDropTargetId(nearestDist < TILE_WIDTH * 0.6 ? nearestId : null);
+            }}
+            onDragEnd={() => {
+              const targetId = dropTargetId;
+              setDraggingId(null);
+              setDropTargetId(null);
+              if (!targetId || targetId === player.id) return;
+
+              // Swap the two seats in the ROTATED view...
+              const next = seated.slice();
+              const a = next.findIndex((p) => p.id === player.id);
+              const b = next.findIndex((p) => p.id === targetId);
+              if (a < 0 || b < 0) return;
+              [next[a], next[b]] = [next[b], next[a]];
+
+              // ...then undo the rotation so the server receives the shared
+              // ring. Rotating by the local player's original offset keeps
+              // everyone else's absolute seats intact.
+              const offset = players.findIndex((p) => p.user_id === currentUserId);
+              const shift = offset > 0 ? offset : 0;
+              const shared = next.map(
+                (_, i) => next[(i - shift + next.length * 2) % next.length],
+              );
+              onReorder(shared.map((p) => p.id));
+            }}
+          >
+            {renderTile(player, {
+              isActiveTurn: player.id === activePlayerId,
+              isDragging: draggingId === player.id,
+              isDropTarget: dropTargetId === player.id,
+            })}
+          </DraggableSeat>
+        ))}
+    </View>
+  );
+}
+
+interface DraggableSeatProps {
+  index: number;
+  origin: { left: number; top: number };
+  isDragging: boolean;
+  onDragStart: () => void;
+  onDragMove: (dx: number, dy: number) => void;
+  onDragEnd: () => void;
+  children: React.ReactNode;
+}
+
+function DraggableSeat({
+  origin,
+  isDragging,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  children,
+}: DraggableSeatProps) {
+  const pan = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
+
+  const responder = useRef(
+    PanResponder.create({
+      // Don't capture the touch on press — the tile's own +/- buttons must
+      // still work. Only claim the gesture once it's clearly a drag.
+      onMoveShouldSetPanResponder: (_evt, gesture) =>
+        Math.abs(gesture.dx) > 6 || Math.abs(gesture.dy) > 6,
+      onPanResponderGrant: () => {
+        pan.setValue({ x: 0, y: 0 });
+        onDragStart();
+      },
+      onPanResponderMove: (evt, gesture) => {
+        pan.setValue({ x: gesture.dx, y: gesture.dy });
+        onDragMove(gesture.dx, gesture.dy);
+      },
+      onPanResponderRelease: () => {
+        onDragEnd();
+        // Spring home: the tile's real position comes from the seat ring once
+        // the server round-trips, so the drag offset must always reset.
+        Animated.spring(pan, {
+          toValue: { x: 0, y: 0 },
+          useNativeDriver: false,
+          friction: 7,
+        }).start();
+      },
+      onPanResponderTerminate: () => {
+        onDragEnd();
+        pan.setValue({ x: 0, y: 0 });
+      },
+    }),
+  ).current;
+
+  return (
+    <Animated.View
+      {...responder.panHandlers}
+      style={[
+        styles.seat,
+        origin,
+        { transform: pan.getTranslateTransform() },
+        isDragging && styles.seatDragging,
+      ]}
+    >
+      {children}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: 'relative',
+    minHeight: 560,
+  },
+  tableSurface: {
+    ...StyleSheet.absoluteFillObject,
+    margin: 90,
+    borderRadius: 9999,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tableCenter: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    padding: 20,
+  },
+  seat: {
+    position: 'absolute',
+    width: TILE_WIDTH,
+    height: TILE_HEIGHT,
+  },
+  seatDragging: {
+    // Lift the dragged tile above its neighbours.
+    zIndex: 10,
+  },
+});

--- a/Treachery/src/components/RoundTable.tsx
+++ b/Treachery/src/components/RoundTable.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-import {
-  Animated,
-  LayoutChangeEvent,
-  PanResponder,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { Animated, LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { Player } from '@/models/types';
 import { TILE_HEIGHT, TILE_WIDTH } from '@/components/PlayerTile';
 import { rotateToLocalFirst, seatPositions } from '@/components/seatPositions';
@@ -23,16 +17,18 @@ import { colors } from '@/constants/theme';
  * who is on whose left, while each person sees the table from their own
  * chair. Dragging therefore changes the shared ring, not just your view.
  *
- * Dragging uses PanResponder + Animated (core React Native, already the
- * codebase's animation approach in PlayerRow) rather than gesture-handler or
- * reanimated: it behaves consistently under react-native-web, where the
- * gesture libraries are fiddlier, and adds no new dependency.
+ * Dragging uses the Pointer Events API (see DraggableSeat below for why
+ * PanResponder does not work here) with core Animated for the transform —
+ * no new dependency.
  *
  * A drop SWAPS the dragged tile with the seat it lands on, rather than
  * splicing the ring. Swapping is what people expect when physically trading
  * chairs, and it keeps everyone else's position stable — a splice would shift
  * every downstream seat and make the board lurch.
  */
+
+/** Breathing room between a tile edge and the board edge. */
+const SEAT_PADDING = 8;
 
 export interface RoundTableProps {
   /** All players, in shared seat order (order_id ascending). */
@@ -78,12 +74,35 @@ export function RoundTable({
     setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
   };
 
+  // seatPositions works in fractions of the container, but tiles are a fixed
+  // pixel size — so a fraction that fits a wide board overflows a narrow one
+  // (the desktop board is a ~560px column once the identity sidebar takes its
+  // half). Rescale the ring to the space actually available after reserving
+  // room for a tile, so the layout is correct at any container size.
+  //
+  // The scale is derived from the positions themselves rather than from the
+  // ellipse constants, so this stays correct if that geometry ever changes.
+  const extent = useMemo(() => {
+    let dx = 0;
+    let dy = 0;
+    for (const p of positions) {
+      dx = Math.max(dx, Math.abs(p.x - 0.5));
+      dy = Math.max(dy, Math.abs(p.y - 0.5));
+    }
+    return { dx, dy };
+  }, [positions]);
+
   /** Absolute top-left pixel position of a seat, given its centre fraction. */
   const seatOrigin = (index: number) => {
     const pos = positions[index] ?? { x: 0.5, y: 0.5 };
+    const availX = Math.max(0, (size.width - TILE_WIDTH) / 2 - SEAT_PADDING);
+    const availY = Math.max(0, (size.height - TILE_HEIGHT) / 2 - SEAT_PADDING);
+    // extent 0 means a single seat dead centre — no offset to scale.
+    const offsetX = extent.dx > 0 ? ((pos.x - 0.5) / extent.dx) * availX : 0;
+    const offsetY = extent.dy > 0 ? ((pos.y - 0.5) / extent.dy) * availY : 0;
     return {
-      left: pos.x * size.width - TILE_WIDTH / 2,
-      top: pos.y * size.height - TILE_HEIGHT / 2,
+      left: size.width / 2 + offsetX - TILE_WIDTH / 2,
+      top: size.height / 2 + offsetY - TILE_HEIGHT / 2,
     };
   };
 
@@ -177,6 +196,21 @@ interface DraggableSeatProps {
   children: React.ReactNode;
 }
 
+/**
+ * Pointer events rather than PanResponder.
+ *
+ * PanResponder never grants on react-native-web here: its gestureState is
+ * synthesised from a touch history that reports zero deltas for mouse input,
+ * and even an unconditional `onMoveShouldSetPanResponder` failed to take the
+ * responder for real (CDP-dispatched) mouse drags. The Pointer Events API is
+ * forwarded straight to the DOM by react-native-web and is supported by React
+ * Native itself since 0.71, so this is the portable choice rather than a
+ * web-only escape hatch.
+ *
+ * `setPointerCapture` keeps the gesture attached to this tile once it starts,
+ * so dragging across a neighbouring tile (or off the board) still tracks and
+ * still delivers the release.
+ */
 function DraggableSeat({
   origin,
   isDragging,
@@ -186,41 +220,62 @@ function DraggableSeat({
   children,
 }: DraggableSeatProps) {
   const pan = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
+  const start = useRef<{ x: number; y: number } | null>(null);
+  const moved = useRef(false);
 
-  const responder = useRef(
-    PanResponder.create({
-      // Don't capture the touch on press — the tile's own +/- buttons must
-      // still work. Only claim the gesture once it's clearly a drag.
-      onMoveShouldSetPanResponder: (_evt, gesture) =>
-        Math.abs(gesture.dx) > 6 || Math.abs(gesture.dy) > 6,
-      onPanResponderGrant: () => {
-        pan.setValue({ x: 0, y: 0 });
-        onDragStart();
-      },
-      onPanResponderMove: (evt, gesture) => {
-        pan.setValue({ x: gesture.dx, y: gesture.dy });
-        onDragMove(gesture.dx, gesture.dy);
-      },
-      onPanResponderRelease: () => {
-        onDragEnd();
-        // Spring home: the tile's real position comes from the seat ring once
-        // the server round-trips, so the drag offset must always reset.
-        Animated.spring(pan, {
-          toValue: { x: 0, y: 0 },
-          useNativeDriver: false,
-          friction: 7,
-        }).start();
-      },
-      onPanResponderTerminate: () => {
-        onDragEnd();
-        pan.setValue({ x: 0, y: 0 });
-      },
-    }),
-  ).current;
+  const handlePointerDown = (e: PointerEventLike) => {
+    // Record the origin but do NOT capture the pointer yet. Capturing here
+    // redirects every later pointer event to this tile, so the +/- buttons
+    // inside it never receive their pointerup and never fire a click.
+    // Capture is taken below, only once the gesture is confirmed a drag.
+    start.current = { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+    moved.current = false;
+  };
+
+  const handlePointerMove = (e: PointerEventLike) => {
+    if (!start.current) return;
+    const dx = e.nativeEvent.clientX - start.current.x;
+    const dy = e.nativeEvent.clientY - start.current.y;
+    // A few pixels of slop so a click on +/- isn't read as a drag.
+    if (!moved.current && Math.abs(dx) < 6 && Math.abs(dy) < 6) return;
+    if (!moved.current) {
+      moved.current = true;
+      // Now that this is definitely a drag, capture so it keeps tracking
+      // across neighbouring tiles and off the board.
+      const target = e.currentTarget as unknown as {
+        setPointerCapture?: (id: number) => void;
+      };
+      target?.setPointerCapture?.(e.nativeEvent.pointerId);
+      onDragStart();
+    }
+    pan.setValue({ x: dx, y: dy });
+    onDragMove(dx, dy);
+  };
+
+  const endDrag = (e: PointerEventLike) => {
+    const target = e.currentTarget as unknown as {
+      releasePointerCapture?: (id: number) => void;
+    };
+    target?.releasePointerCapture?.(e.nativeEvent.pointerId);
+    start.current = null;
+    if (!moved.current) return; // a tap, not a drag — leave it to the buttons
+    moved.current = false;
+    onDragEnd();
+    // Spring home: the tile's real position comes from the seat ring once the
+    // server round-trips, so the drag offset must always reset.
+    Animated.spring(pan, {
+      toValue: { x: 0, y: 0 },
+      useNativeDriver: false,
+      friction: 7,
+    }).start();
+  };
 
   return (
     <Animated.View
-      {...responder.panHandlers}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
       style={[
         styles.seat,
         origin,
@@ -231,6 +286,12 @@ function DraggableSeat({
       {children}
     </Animated.View>
   );
+}
+
+/** Minimal shape of the pointer events react-native-web forwards. */
+interface PointerEventLike {
+  currentTarget: unknown;
+  nativeEvent: { clientX: number; clientY: number; pointerId: number };
 }
 
 const styles = StyleSheet.create({

--- a/Treachery/src/components/seatPositions.ts
+++ b/Treachery/src/components/seatPositions.ts
@@ -1,0 +1,100 @@
+/**
+ * Seat geometry for the desktop "round table" board.
+ *
+ * Coordinate space: fractions of the seating container's box — `x` grows to the
+ * right, `y` grows DOWN (screen coordinates, so the numbers drop straight into
+ * `left`/`top`). `{ x: 0.5, y: 0.5 }` is dead centre, i.e. the table itself.
+ * Every position is the CENTRE of a tile, so a container places one with
+ * `left: x * width - TILE_WIDTH / 2`, `top: y * height - TILE_HEIGHT / 2`.
+ *
+ * Nothing here touches React, the DOM, or the clock: same `count` in, same
+ * array out.
+ */
+
+export interface SeatPosition {
+  /** 0..1 fraction of container width, tile CENTER */
+  x: number;
+  /** 0..1 of height */
+  y: number;
+}
+
+/**
+ * Ellipse radii, also fractions of the container.
+ *
+ * Deliberately wider than tall. A tile is 200x150 (see TILE_WIDTH/TILE_HEIGHT
+ * in PlayerTile), so neighbours collide sideways long before they collide
+ * vertically — spreading seats out horizontally is what buys the clearance.
+ * A circle in fraction space would do the opposite: on a board that is itself
+ * much wider than tall it stacks every seat into a narrow column down the
+ * middle and wastes the flanks.
+ *
+ * The leftover inset (0.5 - radius) is the margin a tile's own half-size has to
+ * fit into. At a representative 1200x700 board that is 0.12*1200 = 144px of
+ * room for a 100px half-width, and 0.16*700 = 112px for a 75px half-height —
+ * comfortable at the sizes the board actually ships at.
+ */
+const RADIUS_X = 0.38;
+const RADIUS_Y = 0.34;
+
+const TAU = Math.PI * 2;
+
+/** Four decimals is finer than any real pixel, and keeps the bottom seat exactly 0.5. */
+function round(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+/**
+ * Positions for `count` seats arranged around a table.
+ * Index 0 is ALWAYS bottom-center (the local player's seat — the container
+ * rotates the roster so "you" sit at the bottom, like a real table).
+ * Remaining seats proceed clockwise.
+ *
+ * Clockwise is read off a clock face: from 6 o'clock the next mark is 7, so
+ * seat 1 sits down-and-left of you and the ring comes back around the right.
+ *
+ * Even angular spacing is enough for every table size we support, and it lands
+ * on an arrangement that looks chosen rather than generated at each count:
+ *
+ *   1  you alone at the bottom seat — the solo life-tracker case; keeping the
+ *      invariant beats floating a lone tile into the middle of the table
+ *   2  bottom and top, the two of you facing each other across the table
+ *   3  an equilateral triangle: you at the bottom, both opponents flanking the top
+ *   4  one seat per side: bottom, left, top, right
+ *   5  a pentagon — a pair low on the flanks, a pair high
+ *   6  a hexagon — a seat at bottom and top with a pair down each side
+ *   7  a heptagon
+ *   8  an octagon, and the tightest table Treachery supports. The closest pair
+ *      is a flank neighbour (45 degrees vs 90 degrees): they overlap in x, and
+ *      it is the ~168px between their centres on a 700px-tall board that keeps
+ *      a 150px-tall tile clear — 18px to spare, and more on a taller board.
+ *   9+ we keep distributing rather than throwing. Nine seats is not a legal
+ *      Treachery game, but a stale roster or a future variant should degrade
+ *      into a crowded ring, not crash the board. Past 8 the ring is tighter
+ *      than a 200x150 tile likes, so a container that ever allows it should
+ *      scale tiles down.
+ */
+export function seatPositions(count: number): SeatPosition[] {
+  if (!Number.isFinite(count)) return [];
+  const seats = Math.floor(count);
+  if (seats < 1) return [];
+
+  const positions: SeatPosition[] = [];
+  for (let i = 0; i < seats; i += 1) {
+    // angle 0 = bottom-center, growing clockwise on screen.
+    const angle = (i / seats) * TAU;
+    positions.push({
+      x: round(0.5 - RADIUS_X * Math.sin(angle)),
+      y: round(0.5 + RADIUS_Y * Math.cos(angle)),
+    });
+  }
+  return positions;
+}
+
+/** Rotate `players` so the entry with the given id sits at index 0 (bottom seat). */
+export function rotateToLocalFirst<T>(items: T[], isLocal: (item: T) => boolean): T[] {
+  const index = items.findIndex((item) => isLocal(item));
+  // No local player (spectator) or already first: hand back a copy either way,
+  // so callers never get an alias of the array they passed in.
+  if (index <= 0) return items.slice();
+  return [...items.slice(index), ...items.slice(0, index)];
+}

--- a/Treachery/src/hooks/useGameBoard.ts
+++ b/Treachery/src/hooks/useGameBoard.ts
@@ -25,6 +25,12 @@ interface UseGameBoardReturn {
   identityCard: (player: Player) => IdentityCard | undefined;
   updatePlayerColor: (color: string | null) => Promise<void>;
   renameCurrentPlayer: (name: string) => Promise<void>;
+  /** Player doc id whose turn it is, or null when unmarked. */
+  activePlayerId: string | null;
+  setActivePlayer: (playerId: string | null) => Promise<void>;
+  advanceTurn: () => Promise<void>;
+  /** Persist a new seating ring (player doc ids, seat 0 first). */
+  reorderSeats: (orderedPlayerIds: string[]) => Promise<void>;
   // Planechase
   isPlanechaseActive: boolean;
   isTreacheryActive: boolean;
@@ -265,6 +271,48 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
     }
   }, [currentPlayer, gameId, isPending]);
 
+  // ── Turn marker & seating ──────────────────────────────────────
+  // Both live on the server: a turn marker or seat ring that differed between
+  // clients would be worse than not having one. Reordering goes through a
+  // callable rather than direct writes because the invariant ("the new order
+  // is a permutation of the current seats") spans documents, which security
+  // rules cannot express.
+
+  const activePlayerId = game?.active_player_id ?? null;
+
+  const setActivePlayer = useCallback(
+    async (playerId: string | null) => {
+      try {
+        const fn = httpsCallable(functions, 'setActivePlayer');
+        await fn({ gameId, playerId });
+      } catch (error: unknown) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to set the turn.');
+      }
+    },
+    [gameId],
+  );
+
+  const advanceTurn = useCallback(async () => {
+    try {
+      const fn = httpsCallable(functions, 'advanceTurn');
+      await fn({ gameId });
+    } catch (error: unknown) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to advance the turn.');
+    }
+  }, [gameId]);
+
+  const reorderSeats = useCallback(
+    async (orderedPlayerIds: string[]) => {
+      try {
+        const fn = httpsCallable(functions, 'reorderSeats');
+        await fn({ gameId, orderedPlayerIds });
+      } catch (error: unknown) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to reorder seats.');
+      }
+    },
+    [gameId],
+  );
+
   const updatePlayerColor = useCallback(
     async (color: string | null) => {
       if (!currentPlayer) return;
@@ -420,6 +468,10 @@ export function useGameBoard(gameId: string, currentUserId: string | null): UseG
     identityCard: identityCardFn,
     updatePlayerColor,
     renameCurrentPlayer,
+    activePlayerId,
+    setActivePlayer,
+    advanceTurn,
+    reorderSeats,
     // Planechase
     isPlanechaseActive,
     isTreacheryActive,

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -70,6 +70,10 @@ export interface Game {
   // Caps which traitor identities can appear in startGame's random pool.
   // Absent means no cap ('special' — all traitors allowed).
   max_traitor_rarity?: Rarity;
+  // Player DOC id whose turn it is (not a seat index — seats can be dragged
+  // around, and the turn must follow the person, not the chair). Absent or
+  // null means no turn is marked.
+  active_player_id?: string | null;
 }
 
 export interface Player {

--- a/functions/index.js
+++ b/functions/index.js
@@ -705,6 +705,10 @@ exports.startGame = onCall(callableOptions, async (request) => {
     const gameUpdate = {
       state: "in_progress",
       last_activity_at: FieldValue.serverTimestamp(),
+      // Turn starts on the first seat. Optional field — clients that don't
+      // know about turns ignore it, and a game doc without it simply has no
+      // active player highlighted.
+      active_player_id: players.length > 0 ? players[0].ref.id : null,
     };
 
     if (includesPlanechase && !(game.planechase?.use_own_deck)) {
@@ -1850,6 +1854,184 @@ exports.updateGameSettings = onCall(callableOptions, async (request) => {
     }
 
     return { success: true };
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CLOUD FUNCTION: setActivePlayer
+// Sets whose turn it is. Any player at the table may set it —
+// this is a shared companion app for an in-person game, not an
+// enforcement engine, and the same permissiveness already applies
+// to adjustLife.
+// ════════════════════════════════════════════════════════════════
+
+exports.setActivePlayer = onCall(callableOptions, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { gameId, playerId } = request.data;
+  if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
+
+  return db.runTransaction(async (tx) => {
+    const gameRef = db.doc(`games/${gameId}`);
+    const gameSnap = await tx.get(gameRef);
+    if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
+    const game = gameSnap.data();
+
+    if (game.state !== "in_progress") {
+      throw new HttpsError("failed-precondition", "Game is not in progress.");
+    }
+    if (!(game.player_ids || []).includes(uid)) {
+      throw new HttpsError("permission-denied", "You are not in this game.");
+    }
+
+    // null clears the turn marker; anything else must be a real player.
+    if (playerId !== null && playerId !== undefined) {
+      const playerSnap = await tx.get(db.doc(`games/${gameId}/players/${playerId}`));
+      if (!playerSnap.exists) throw new HttpsError("not-found", "Player not found.");
+      if (playerSnap.data().is_eliminated) {
+        throw new HttpsError("failed-precondition", "That player is eliminated.");
+      }
+    }
+
+    tx.update(gameRef, {
+      active_player_id: playerId ?? null,
+      last_activity_at: FieldValue.serverTimestamp(),
+    });
+
+    return { activePlayerId: playerId ?? null };
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CLOUD FUNCTION: advanceTurn
+// Moves the turn to the next seat, skipping eliminated players.
+// ════════════════════════════════════════════════════════════════
+
+exports.advanceTurn = onCall(callableOptions, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { gameId } = request.data;
+  if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
+
+  return db.runTransaction(async (tx) => {
+    const gameRef = db.doc(`games/${gameId}`);
+    const gameSnap = await tx.get(gameRef);
+    if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
+    const game = gameSnap.data();
+
+    if (game.state !== "in_progress") {
+      throw new HttpsError("failed-precondition", "Game is not in progress.");
+    }
+    if (!(game.player_ids || []).includes(uid)) {
+      throw new HttpsError("permission-denied", "You are not in this game.");
+    }
+
+    const playersSnap = await tx.get(
+      db.collection(`games/${gameId}/players`).orderBy("order_id")
+    );
+    const seats = playersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const alive = seats.filter((p) => !p.is_eliminated);
+
+    // Everyone eliminated: nothing sensible to advance to. Clear the marker
+    // rather than pointing at a dead seat.
+    if (alive.length === 0) {
+      tx.update(gameRef, {
+        active_player_id: null,
+        last_activity_at: FieldValue.serverTimestamp(),
+      });
+      return { activePlayerId: null };
+    }
+
+    // Walk forward from the current seat around the ring to the next living
+    // player. Starting from -1 when unset means an unset turn advances to the
+    // first seat rather than nowhere.
+    const currentIndex = seats.findIndex((p) => p.id === game.active_player_id);
+    let next = null;
+    for (let step = 1; step <= seats.length; step++) {
+      const candidate = seats[(currentIndex + step + seats.length) % seats.length];
+      if (!candidate.is_eliminated) {
+        next = candidate;
+        break;
+      }
+    }
+
+    tx.update(gameRef, {
+      active_player_id: next.id,
+      last_activity_at: FieldValue.serverTimestamp(),
+    });
+
+    return { activePlayerId: next.id };
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// CLOUD FUNCTION: reorderSeats
+// Rewrites every player's order_id to match a caller-supplied
+// seating order — the persistence behind dragging players around
+// the table. Runs server-side rather than through security rules
+// because the invariant is "the new order is a PERMUTATION of the
+// existing seats", which spans documents and rules cannot express.
+//
+// Side benefit: because it always writes a contiguous 0..N-1 run,
+// it also repairs duplicate order_ids if a client ever left the ring
+// in a bad state. leaveGame already renumbers survivors.
+// ════════════════════════════════════════════════════════════════
+
+exports.reorderSeats = onCall(callableOptions, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Must be signed in.");
+
+  const { gameId, orderedPlayerIds } = request.data;
+  if (!gameId) throw new HttpsError("invalid-argument", "gameId is required.");
+  if (!Array.isArray(orderedPlayerIds)) {
+    throw new HttpsError("invalid-argument", "orderedPlayerIds must be an array.");
+  }
+
+  return db.runTransaction(async (tx) => {
+    const gameRef = db.doc(`games/${gameId}`);
+    const gameSnap = await tx.get(gameRef);
+    if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
+    const game = gameSnap.data();
+
+    if (!(game.player_ids || []).includes(uid)) {
+      throw new HttpsError("permission-denied", "You are not in this game.");
+    }
+
+    const playersSnap = await tx.get(db.collection(`games/${gameId}/players`));
+    const existingIds = playersSnap.docs.map((d) => d.id);
+
+    // Permutation check: same size, no duplicates, exactly the same members.
+    // Without this a caller could drop players out of the seating (leaving
+    // them with a stale order_id) or smuggle in ids from another game.
+    if (orderedPlayerIds.length !== existingIds.length) {
+      throw new HttpsError(
+        "invalid-argument",
+        `Expected ${existingIds.length} seats, got ${orderedPlayerIds.length}.`
+      );
+    }
+    const seen = new Set();
+    const existing = new Set(existingIds);
+    for (const id of orderedPlayerIds) {
+      if (typeof id !== "string") {
+        throw new HttpsError("invalid-argument", "Seat ids must be strings.");
+      }
+      if (seen.has(id)) {
+        throw new HttpsError("invalid-argument", `Duplicate seat id: ${id}`);
+      }
+      if (!existing.has(id)) {
+        throw new HttpsError("invalid-argument", `Unknown player id: ${id}`);
+      }
+      seen.add(id);
+    }
+
+    orderedPlayerIds.forEach((playerId, index) => {
+      tx.update(db.doc(`games/${gameId}/players/${playerId}`), { order_id: index });
+    });
+    tx.update(gameRef, { last_activity_at: FieldValue.serverTimestamp() });
+
+    return { success: true, seats: orderedPlayerIds.length };
   });
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -183,6 +183,18 @@ function checkWinConditions(players, gameMode) {
   return null; // Game continues
 }
 
+/** Next living seat after `currentId` (order_id order). Unset current → first living. */
+function nextLivingPlayerId(seats, currentId) {
+  const alive = seats.filter((p) => !p.is_eliminated);
+  if (alive.length === 0) return null;
+  const currentIndex = seats.findIndex((p) => p.id === currentId);
+  for (let step = 1; step <= seats.length; step++) {
+    const candidate = seats[(currentIndex + step + seats.length) % seats.length];
+    if (!candidate.is_eliminated) return candidate.id;
+  }
+  return alive[0].id;
+}
+
 // Sanitize commander names before using them as Firestore map field keys.
 // Dots fragment nested paths; `/ ~ * [ ]` are illegal field-path characters.
 function sanitizeCommanderKey(name) {
@@ -790,29 +802,33 @@ exports.adjustLife = onCall(callableOptions, async (request) => {
     if (eliminated) playerUpdate.is_unveiled = true;
     tx.update(playerRef, playerUpdate);
 
-    tx.update(gameRef, {
+    const gameUpdate = {
       last_activity_at: FieldValue.serverTimestamp(),
-    });
+    };
 
     // If eliminated, check win conditions using the already-read players
     let winner = null;
     if (eliminated) {
-      const allPlayers = allPlayersSnap.docs.map((d) => {
+      const seats = allPlayersSnap.docs.map((d) => {
         const data = d.data();
         if (d.id === playerId) {
-          return { ...data, is_eliminated: true, life_total: 0 };
+          return { id: d.id, ...data, is_eliminated: true, life_total: 0 };
         }
-        return data;
+        return { id: d.id, ...data };
       });
 
-      winner = checkWinConditions(allPlayers, game.game_mode);
+      winner = checkWinConditions(seats, game.game_mode);
       if (winner) {
-        tx.update(gameRef, {
-          state: "finished",
-          winning_team: winner,
-        });
+        gameUpdate.state = "finished";
+        gameUpdate.winning_team = winner;
+      }
+      // Don't leave the turn marker pointing at a corpse.
+      if (game.active_player_id === playerId) {
+        gameUpdate.active_player_id = nextLivingPlayerId(seats, playerId);
       }
     }
+
+    tx.update(gameRef, gameUpdate);
 
     return { newLife, eliminated, winner };
   });
@@ -882,11 +898,6 @@ exports.eliminatePlayer = onCall(callableOptions, async (request) => {
       is_unveiled: true,
     });
 
-    // Update activity timestamp
-    tx.update(gameRef, {
-      last_activity_at: FieldValue.serverTimestamp(),
-    });
-
     // Check win conditions with updated state
     const updatedPlayers = allPlayers.map((p) => {
       if (p.id === callerPlayer.id) {
@@ -895,13 +906,18 @@ exports.eliminatePlayer = onCall(callableOptions, async (request) => {
       return p;
     });
 
+    const gameUpdate = {
+      last_activity_at: FieldValue.serverTimestamp(),
+    };
     const winner = checkWinConditions(updatedPlayers, game.game_mode);
     if (winner) {
-      tx.update(gameRef, {
-        state: "finished",
-        winning_team: winner,
-      });
+      gameUpdate.state = "finished";
+      gameUpdate.winning_team = winner;
     }
+    if (game.active_player_id === callerPlayer.id) {
+      gameUpdate.active_player_id = nextLivingPlayerId(updatedPlayers, callerPlayer.id);
+    }
+    tx.update(gameRef, gameUpdate);
 
     return { success: true };
   });
@@ -1932,37 +1948,14 @@ exports.advanceTurn = onCall(callableOptions, async (request) => {
       db.collection(`games/${gameId}/players`).orderBy("order_id")
     );
     const seats = playersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
-    const alive = seats.filter((p) => !p.is_eliminated);
-
-    // Everyone eliminated: nothing sensible to advance to. Clear the marker
-    // rather than pointing at a dead seat.
-    if (alive.length === 0) {
-      tx.update(gameRef, {
-        active_player_id: null,
-        last_activity_at: FieldValue.serverTimestamp(),
-      });
-      return { activePlayerId: null };
-    }
-
-    // Walk forward from the current seat around the ring to the next living
-    // player. Starting from -1 when unset means an unset turn advances to the
-    // first seat rather than nowhere.
-    const currentIndex = seats.findIndex((p) => p.id === game.active_player_id);
-    let next = null;
-    for (let step = 1; step <= seats.length; step++) {
-      const candidate = seats[(currentIndex + step + seats.length) % seats.length];
-      if (!candidate.is_eliminated) {
-        next = candidate;
-        break;
-      }
-    }
+    const nextId = nextLivingPlayerId(seats, game.active_player_id);
 
     tx.update(gameRef, {
-      active_player_id: next.id,
+      active_player_id: nextId,
       last_activity_at: FieldValue.serverTimestamp(),
     });
 
-    return { activePlayerId: next.id };
+    return { activePlayerId: nextId };
   });
 });
 
@@ -1997,6 +1990,9 @@ exports.reorderSeats = onCall(callableOptions, async (request) => {
 
     if (!(game.player_ids || []).includes(uid)) {
       throw new HttpsError("permission-denied", "You are not in this game.");
+    }
+    if (game.state === "finished") {
+      throw new HttpsError("failed-precondition", "Game is already finished.");
     }
 
     const playersSnap = await tx.get(db.collection(`games/${gameId}/players`));

--- a/functions/test/integration/callables/turns-and-seats.test.js
+++ b/functions/test/integration/callables/turns-and-seats.test.js
@@ -1,0 +1,306 @@
+'use strict';
+
+/**
+ * INTEGRATION: exports.setActivePlayer / advanceTurn / reorderSeats
+ * (functions/index.js)
+ *
+ * The server half of the Round Table board: whose turn it is, and the seating
+ * order players drag tiles into. Both are shared state on purpose — a turn
+ * marker or seat ring that differed per client would be worse than none.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+after(async () => {
+  await h.shutdown();
+});
+
+/** Player doc ids in seat order (order_id ascending). */
+async function seatIds(gameId) {
+  const players = await h.getPlayers(gameId);
+  return players
+    .slice()
+    .sort((a, b) => a.order_id - b.order_id)
+    .map((p) => p.id);
+}
+
+/**
+ * A valid role/card layout for `count` players — seedStartedGame needs the
+ * assignments to match getRoleDistribution exactly or startGame rejects them.
+ * These tests don't care which role sits where, only about seats and turns.
+ */
+function seatsFor(count) {
+  const dist = h.EXPECTED_DISTRIBUTION[count];
+  if (!dist) throw new Error(`No distribution for ${count} players`);
+  const seats = [];
+  for (const role of ['leader', 'guardian', 'assassin', 'traitor']) {
+    for (let i = 0; i < dist[role]; i++) {
+      seats.push({ role, card: `${role}_${String(seats.filter((s) => s.role === role).length + 1).padStart(2, '0')}` });
+    }
+  }
+  return seats;
+}
+
+/** seedStartedGame with an auto-built legal role layout. */
+function startGameFor(users) {
+  return h.seedStartedGame({ users, seats: seatsFor(users.length), startingLife: 40 });
+}
+
+describe('startGame seeds the turn marker', () => {
+  it('sets active_player_id to the first seat', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.active_player_id, seats[0]);
+  });
+});
+
+describe('setActivePlayer', () => {
+  it('lets any player at the table set the turn', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    // users[2], not the host — this is a shared table, not a host-run session.
+    await users[2].call('setActivePlayer', { gameId: game.gameId, playerId: seats[3] });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[3]);
+  });
+
+  it('clears the marker when passed null', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: null });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, null);
+  });
+
+  it('rejects a non-participant', async () => {
+    const users = await h.getUsers(5);
+    const game = await startGameFor(users.slice(0, 4));
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[4].call('setActivePlayer', { gameId: game.gameId, playerId: seats[0] }),
+      'permission-denied'
+    );
+  });
+
+  it('rejects an unknown player id', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    await h.expectHttpsError(
+      users[0].call('setActivePlayer', { gameId: game.gameId, playerId: 'not-a-player' }),
+      'not-found'
+    );
+  });
+
+  it('refuses to hand the turn to an eliminated player', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.patchPlayer(game.gameId, seats[2], { is_eliminated: true, life_total: 0 });
+    await h.expectHttpsError(
+      users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[2] }),
+      'failed-precondition'
+    );
+  });
+});
+
+describe('advanceTurn', () => {
+  it('moves to the next seat', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[0] });
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[1]);
+  });
+
+  it('wraps around from the last seat to the first', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[3] });
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[0]);
+  });
+
+  it('skips eliminated players', async () => {
+    const users = await h.getUsers(5);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await h.patchPlayer(game.gameId, seats[1], { is_eliminated: true, life_total: 0 });
+    await h.patchPlayer(game.gameId, seats[2], { is_eliminated: true, life_total: 0 });
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[0] });
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal(
+      (await h.getGame(game.gameId)).active_player_id,
+      seats[3],
+      'should jump past both eliminated seats'
+    );
+  });
+
+  it('advances to the first living seat when no turn is set', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: null });
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[0]);
+  });
+
+  it('stays on the sole survivor rather than stalling', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    for (const id of seats.slice(1)) {
+      await h.patchPlayer(game.gameId, id, { is_eliminated: true, life_total: 0 });
+    }
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[0] });
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[0]);
+  });
+
+  it('clears the marker when everyone is eliminated', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    for (const id of seats) {
+      await h.patchPlayer(game.gameId, id, { is_eliminated: true, life_total: 0 });
+    }
+    await users[0].call('advanceTurn', { gameId: game.gameId });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, null);
+  });
+
+  it('rejects a non-participant', async () => {
+    const users = await h.getUsers(5);
+    const game = await startGameFor(users.slice(0, 4));
+    await h.expectHttpsError(
+      users[4].call('advanceTurn', { gameId: game.gameId }),
+      'permission-denied'
+    );
+  });
+});
+
+describe('reorderSeats', () => {
+  it('rewrites order_id to the supplied seating', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    const shuffled = [seats[2], seats[0], seats[3], seats[1]];
+
+    await users[1].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: shuffled });
+    assert.deepEqual(await seatIds(game.gameId), shuffled);
+  });
+
+  it('always writes a contiguous 0..N-1 run', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: seats });
+    const players = await h.getPlayers(game.gameId);
+    const ids = players.map((p) => p.order_id).sort((a, b) => a - b);
+    assert.deepEqual(ids, [0, 1, 2, 3]);
+  });
+
+  it('repairs duplicate order_ids left in a broken ring', async () => {
+    // Simulate a corrupt ring (duplicate order_id). Reordering must
+    // rewrite a contiguous 0..N-1 run regardless of how it got that way.
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.patchPlayer(game.gameId, seats[3], { order_id: 2 }); // collide with seats[2]
+
+    await users[0].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: seats });
+    const players = await h.getPlayers(game.gameId);
+    const ids = players.map((p) => p.order_id).sort((a, b) => a - b);
+    assert.deepEqual(ids, [0, 1, 2, 3], 'duplicates must be gone');
+  });
+
+  it('rejects a list that drops a player', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[0].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: seats.slice(1) }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects duplicate ids', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[0].call('reorderSeats', {
+        gameId: game.gameId,
+        orderedPlayerIds: [seats[0], seats[0], seats[1], seats[2]],
+      }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects an id that is not a seat in this game', async () => {
+    // Note there is deliberately no "id smuggled from another game" test:
+    // player docs live at games/{gameId}/players/{id}, so the gameId already
+    // scopes every write. An id from elsewhere either also names a real seat
+    // here (in which case reordering it is legitimate) or doesn't exist and is
+    // caught below. The harness even seeds both games with the same ids
+    // (p0..p3), which makes the cross-game framing meaningless.
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[0].call('reorderSeats', {
+        gameId: game.gameId,
+        orderedPlayerIds: ['no-such-player', seats[1], seats[2], seats[3]],
+      }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a non-string seat id', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[0].call('reorderSeats', {
+        gameId: game.gameId,
+        orderedPlayerIds: [42, seats[1], seats[2], seats[3]],
+      }),
+      'invalid-argument'
+    );
+  });
+
+  it('rejects a non-participant', async () => {
+    const users = await h.getUsers(5);
+    const game = await startGameFor(users.slice(0, 4));
+    const seats = await seatIds(game.gameId);
+    await h.expectHttpsError(
+      users[4].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: seats }),
+      'permission-denied'
+    );
+  });
+
+  it('leaves the turn marker pointing at the same player after a reorder', async () => {
+    // The marker stores a player doc id, not a seat index, precisely so that
+    // dragging seats around doesn't silently hand the turn to someone else.
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[1] });
+    await users[0].call('reorderSeats', {
+      gameId: game.gameId,
+      orderedPlayerIds: [seats[3], seats[1], seats[0], seats[2]],
+    });
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[1]);
+  });
+});

--- a/functions/test/integration/callables/turns-and-seats.test.js
+++ b/functions/test/integration/callables/turns-and-seats.test.js
@@ -303,4 +303,57 @@ describe('reorderSeats', () => {
     });
     assert.equal((await h.getGame(game.gameId)).active_player_id, seats[1]);
   });
+
+  it('rejects a reorder after the game has finished', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+    await h.patchGame(game.gameId, { state: 'finished', winning_team: 'leader' });
+    await h.expectHttpsError(
+      users[0].call('reorderSeats', { gameId: game.gameId, orderedPlayerIds: seats }),
+      'failed-precondition'
+    );
+  });
+});
+
+describe('elimination advances a stale turn marker', () => {
+  it('forfeit of the active player hands the turn to the next living seat', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    // Seat 0 is the leader (seatsFor layout). Forfeiting them would end the
+    // game. Put the turn on the first assassin and have them forfeit instead.
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[1] });
+    await users[1].call('eliminatePlayer', { gameId: game.gameId });
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'in_progress');
+    assert.equal(g.active_player_id, seats[2]);
+  });
+
+  it('life-to-zero of the active player also advances the turn', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[1] });
+    await users[0].call('adjustLife', { gameId: game.gameId, playerId: seats[1], amount: -40 });
+
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'in_progress');
+    assert.equal(g.active_player_id, seats[2]);
+    assert.equal((await h.getPlayer(game.gameId, seats[1])).is_eliminated, true);
+  });
+
+  it('eliminating a non-active player leaves the marker alone', async () => {
+    const users = await h.getUsers(4);
+    const game = await startGameFor(users);
+    const seats = await seatIds(game.gameId);
+
+    await users[0].call('setActivePlayer', { gameId: game.gameId, playerId: seats[0] });
+    await users[2].call('eliminatePlayer', { gameId: game.gameId });
+
+    assert.equal((await h.getGame(game.gameId)).active_player_id, seats[0]);
+  });
 });


### PR DESCRIPTION
**Direction A** from the desktop proposals. On desktop the board becomes player tiles around a table; **mobile is untouched** (still `PlayerRow` in a `FlatList`).

<img width="700" alt="Round table board" src="https://github.com/user-attachments/assets/placeholder" />

### The proposal said "no schema changes" — your two additions require them
Seat order and a turn marker are only useful if the whole table agrees on them, so both are server state.

| Callable | Behaviour |
|---|---|
| `setActivePlayer` | sets/clears the turn; rejects eliminated players |
| `advanceTurn` | next seat, skipping eliminated, wrapping around, clearing when nobody is left |
| `reorderSeats` | atomically rewrites `order_id` to a caller-supplied seating |

Two decisions worth reviewing:

**`active_player_id` stores a player DOC ID, not a seat index** — otherwise dragging seats around would silently hand the turn to whoever landed in that chair. There's a test for exactly that.

**Reordering is a callable, not a rules change** — the invariant is "the new order is a *permutation* of the current seats", which spans documents and is precisely what security rules can't express. **So this PR contains no rules change and no project-wide deploy.** Any player may reorder or set the turn (matching `adjustLife`) — it's a shared companion app, not an enforcement engine.

**Free fix:** because `reorderSeats` always writes a contiguous `0..N-1`, it repairs the duplicate `order_id`s `leaveGame` leaves behind — an open KNOWN-ISSUES entry.

### Player counts
Seat geometry handles **1–8** as deliberate shapes (2 face off, 3 a triangle, 4 the sides, up to an octagon). The container rescales the ring to the space it actually has — the board is a ~560px column once the identity sidebar takes its half, and a fraction-based ellipse sized for a wide canvas overflowed it.

Every client rotates the shared ring so **you** sit bottom-centre: everyone agrees who's on whose left, while each person views the table from their own chair. Say the word if you'd rather have one fixed orientation.

### Two implementation notes that cost real time
**PanResponder does not work for mouse drags under react-native-web.** Its `gestureState` is synthesised from a touch history reporting zero deltas for mouse input, so a distance-gated handler never opens — and even an unconditional `onMoveShouldSetPanResponder` failed to take the responder for genuine CDP-dispatched drags. Rewritten on the Pointer Events API (RN-web forwards it to the DOM; RN supports it natively since 0.71).

**Pointer capture is taken only after 6px of movement.** Capturing on `pointerdown` swallows the `pointerup` that a tile's own +/- buttons need, which silently broke life adjustment entirely. Caught by a test, not by me.

### Role visibility
Board visibility now goes through an explicit `mayRevealRole` instead of `canSeeRole`, which reports `true` for your own player. `PlayerRow` has always ignored that prop (the audit's dead-prop finding), so honouring it properly in the new tile surfaced latent behaviour. The rule now mirrors the game: Leaders public → unveiled roles public to everyone including yourself → your own concealed role stays in the header → everyone else via `canSeeRole`, so the Puppet Master peek still works. **No player can see another player's concealed role** — the visibility specs enforce this and pass.

### Tests
- **22 new integration tests** over the three callables — 141 passing.
- **`e2e/round-table.spec.ts`** — seat ring renders, turn marker advances for the whole table, a drag persists as a genuine swap and converges on another player's client, and a life-button tap is not read as a drag.
- Full E2E: **34 passed / 8 skipped**. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)