### PR TITLE
Harden Cloud Functions against callable cheats

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -124,7 +124,7 @@ function getRoleDistribution(playerCount) {
     7: { leaders: 1, guardians: 2, assassins: 3, traitors: 1 },
     8: { leaders: 1, guardians: 2, assassins: 3, traitors: 2 },
   };
-  return table[playerCount] || { leaders: 1, guardians: 0, assassins: 2, traitors: 1 };
+  return table[playerCount] || null;
 }
 
 // ── Shuffle (Fisher-Yates) ──
@@ -147,6 +147,28 @@ const TREACHERY_MODES = new Set(["treachery", "treachery_planechase"]);
 function isTreacheryMode(gameMode) {
   // Default missing mode to treachery for legacy games that used roles.
   return gameMode == null || TREACHERY_MODES.has(gameMode);
+}
+
+const PLANECHASE_MODES = new Set(["planechase", "treachery_planechase"]);
+
+function isPlanechaseMode(gameMode) {
+  return PLANECHASE_MODES.has(gameMode);
+}
+
+function assertSeatedInGame(game, uid) {
+  if (!(game.player_ids || []).includes(uid)) {
+    throw new HttpsError("permission-denied", "You are not in this game.");
+  }
+}
+
+function assertPlanechasePlay(game, uid) {
+  if (game.state !== "in_progress") {
+    throw new HttpsError("failed-precondition", "Game is not in progress.");
+  }
+  if (!isPlanechaseMode(game.game_mode)) {
+    throw new HttpsError("failed-precondition", "This game is not Planechase.");
+  }
+  assertSeatedInGame(game, uid);
 }
 
 function checkWinConditions(players, gameMode) {
@@ -598,6 +620,10 @@ exports.startGame = onCall(callableOptions, async (request) => {
     );
     const players = playersSnap.docs.map((d) => ({ ref: d.ref, ...d.data() }));
 
+    if (players.length > 8) {
+      throw new HttpsError("failed-precondition", "Games support at most 8 players.");
+    }
+
     if (includesTreachery) {
       // Validate minimum player count against role distribution
       if (players.length < 1) {
@@ -605,6 +631,9 @@ exports.startGame = onCall(callableOptions, async (request) => {
       }
 
       const dist = getRoleDistribution(players.length);
+      if (!dist) {
+        throw new HttpsError("failed-precondition", "Unsupported player count.");
+      }
 
       // Test-seed override: when running in the firebase emulator, accept an
       // explicit { user_id -> { role, identityCardId } } map so E2E tests can
@@ -1385,6 +1414,9 @@ exports.resolveWearerOfMasks = onCall(callableOptions, async (request) => {
     if (caller.identity_card_id !== "traitor_13") {
       throw new HttpsError("failed-precondition", "Your card is not The Wearer of Masks.");
     }
+    if (caller.original_identity_card_id && caller.original_identity_card_id !== "traitor_13") {
+      throw new HttpsError("failed-precondition", "Your card is not The Wearer of Masks.");
+    }
     if (!caller.is_unveiled) {
       throw new HttpsError("failed-precondition", "You must unveil first.");
     }
@@ -1452,11 +1484,7 @@ exports.rollPlanarDie = onCall(callableOptions, async (request) => {
     const gameSnap = await tx.get(gameRef);
     if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
     const game = gameSnap.data();
-
-    if (game.state !== "in_progress")
-      throw new HttpsError("failed-precondition", "Game is not in progress.");
-    if (!(game.player_ids || []).includes(uid))
-      throw new HttpsError("permission-denied", "You are not in this game.");
+    assertPlanechasePlay(game, uid);
 
     const planechase = game.planechase || {};
 
@@ -1610,9 +1638,7 @@ exports.resolvePhenomenon = onCall(callableOptions, async (request) => {
     const gameSnap = await tx.get(gameRef);
     if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
     const game = gameSnap.data();
-
-    if (game.state !== "in_progress")
-      throw new HttpsError("failed-precondition", "Game is not in progress.");
+    assertPlanechasePlay(game, uid);
 
     const planechase = game.planechase || {};
     if (planechase.use_own_deck)
@@ -1673,7 +1699,11 @@ exports.resolvePhenomenon = onCall(callableOptions, async (request) => {
         name: p.name,
       }));
 
-      // Do NOT update game state — wait for selectPlane call
+      tx.update(gameRef, {
+        "planechase.pending_plane_options": options.map((o) => o.id),
+        last_activity_at: FieldValue.serverTimestamp(),
+      });
+
       return { type: "choose", options };
     } else if (currentPlane.id === SPATIAL_MERGING_ID) {
       // Spatial Merging: pick 2 random non-phenomenon planes
@@ -1732,11 +1762,19 @@ exports.selectPlane = onCall(callableOptions, async (request) => {
     const gameSnap = await tx.get(gameRef);
     if (!gameSnap.exists) throw new HttpsError("not-found", "Game not found.");
     const game = gameSnap.data();
+    assertPlanechasePlay(game, uid);
 
-    if (game.state !== "in_progress")
-      throw new HttpsError("failed-precondition", "Game is not in progress.");
-    if (!(game.player_ids || []).includes(uid))
-      throw new HttpsError("permission-denied", "You are not in this game.");
+    const planechase = game.planechase || {};
+    if (planechase.use_own_deck) {
+      throw new HttpsError("failed-precondition", "Using own deck.");
+    }
+    if (planechase.current_plane_id !== INTERPLANAR_TUNNEL_ID) {
+      throw new HttpsError("failed-precondition", "No Interplanar Tunnel to resolve.");
+    }
+    const pending = planechase.pending_plane_options || [];
+    if (!pending.includes(planeId)) {
+      throw new HttpsError("invalid-argument", "Plane was not offered.");
+    }
 
     // Validate the chosen plane exists and is not a phenomenon
     const chosenPlane = PLANE_CARDS.find((p) => p.id === planeId);
@@ -1745,13 +1783,13 @@ exports.selectPlane = onCall(callableOptions, async (request) => {
     if (chosenPlane.is_phenomenon)
       throw new HttpsError("invalid-argument", "Cannot select a phenomenon.");
 
-    const planechase = game.planechase || {};
     let usedPlaneIds = planechase.used_plane_ids || [];
     usedPlaneIds = [...usedPlaneIds, planeId];
 
     tx.update(gameRef, {
       "planechase.current_plane_id": planeId,
       "planechase.used_plane_ids": usedPlaneIds,
+      "planechase.pending_plane_options": FieldValue.delete(),
       last_activity_at: FieldValue.serverTimestamp(),
     });
 
@@ -1788,7 +1826,12 @@ exports.endGame = onCall(callableOptions, async (request) => {
       last_activity_at: FieldValue.serverTimestamp(),
     };
     if (winnerUserIds && Array.isArray(winnerUserIds) && winnerUserIds.length > 0) {
-      update.winner_user_ids = winnerUserIds;
+      const seated = new Set(game.player_ids || []);
+      const unique = [...new Set(winnerUserIds)];
+      if (unique.some((id) => typeof id !== "string" || !seated.has(id))) {
+        throw new HttpsError("invalid-argument", "Winners must be players in this game.");
+      }
+      update.winner_user_ids = unique;
     }
     tx.update(gameRef, update);
 
@@ -1833,6 +1876,13 @@ exports.updateGameSettings = onCall(callableOptions, async (request) => {
     if (maxPlayers !== undefined) {
       const mp = parseIntegerArg(maxPlayers, { min: 2, max: 8 });
       if (mp === null) throw new HttpsError("invalid-argument", "Max players must be 2-8.");
+      const seated = (game.player_ids || []).length;
+      if (mp < seated) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Cannot set max players below the current lobby size."
+        );
+      }
       update.max_players = mp;
     }
 
@@ -2151,7 +2201,7 @@ exports.onGameFinished = onDocumentUpdated("games/{gameId}", async (event) => {
   let winnerUserIds = [];
   let loserUserIds = [];
 
-  if (game.game_mode === "treachery" || game.game_mode === "treachery_planechase") {
+  if (isTreacheryMode(game.game_mode)) {
     // Treachery: use winning_team
     const winningTeam = game.winning_team;
     if (!winningTeam) return;

--- a/functions/test/integration/callables/adjust-life.test.js
+++ b/functions/test/integration/callables/adjust-life.test.js
@@ -321,4 +321,23 @@ describe('adjustLife — non-treachery modes must not auto-finish', () => {
       assert.equal(g.winning_team, undefined);
     }
   );
+
+  it('rejects winnerUserIds that are not seated in the game', async () => {
+    const users = await h.getUsers(5);
+    const seated = users.slice(0, 4);
+    const outsider = users[4];
+    const game = await h.seedGame({ users: seated, gameMode: 'none', startingLife: 40 });
+    await game.host.call('startGame', { gameId: game.gameId });
+
+    await h.expectHttpsError(
+      game.host.call('endGame', {
+        gameId: game.gameId,
+        winnerUserIds: [outsider.uid],
+      }),
+      'invalid-argument'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'in_progress');
+    assert.equal(g.winner_user_ids, undefined);
+  });
 });

--- a/functions/test/integration/callables/planechase.test.js
+++ b/functions/test/integration/callables/planechase.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * INTEGRATION: planechase callables (rollPlanarDie, resolvePhenomenon, selectPlane)
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const h = require('./helpers');
+
+const INTERPLANAR_TUNNEL_ID = '7812174b-2dc1-43e8-b98f-639905e20ab7';
+const ACADEMY_PLANE_ID = '15b979de-c8ee-4664-9ca7-6c4eb3346967';
+
+after(async () => {
+  await h.shutdown();
+});
+
+async function startedPlanechase(userCount = 2, extra = {}) {
+  const users = await h.getUsers(userCount);
+  const seated = users.slice(0, 2);
+  const game = await h.seedGame({ users: seated, gameMode: 'planechase', ...extra });
+  await game.host.call('startGame', { gameId: game.gameId });
+  return { game, users, outsider: users[2] };
+}
+
+describe('planechase callables — authz', () => {
+  it('rejects rollPlanarDie from a non-seated user', async () => {
+    const { game, outsider } = await startedPlanechase(3);
+    await h.expectHttpsError(
+      outsider.call('rollPlanarDie', { gameId: game.gameId }),
+      'permission-denied'
+    );
+  });
+
+  it('rejects rollPlanarDie in a treachery-only game', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users, gameMode: 'treachery' });
+    await game.host.call('startGame', { gameId: game.gameId });
+    await h.expectHttpsError(
+      game.host.call('rollPlanarDie', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects resolvePhenomenon from a non-seated user', async () => {
+    const { game, outsider } = await startedPlanechase(3);
+    await h.patchGame(game.gameId, {
+      'planechase.current_plane_id': INTERPLANAR_TUNNEL_ID,
+    });
+    await h.expectHttpsError(
+      outsider.call('resolvePhenomenon', { gameId: game.gameId }),
+      'permission-denied'
+    );
+  });
+});
+
+describe('selectPlane', () => {
+  it('rejects cherry-picking a plane without an Interplanar Tunnel offer', async () => {
+    const { game } = await startedPlanechase();
+    await h.expectHttpsError(
+      game.host.call('selectPlane', { gameId: game.gameId, planeId: ACADEMY_PLANE_ID }),
+      'failed-precondition'
+    );
+  });
+
+  it('rejects a plane that was not among the persisted tunnel options', async () => {
+    const { game } = await startedPlanechase();
+    await h.patchGame(game.gameId, {
+      'planechase.current_plane_id': INTERPLANAR_TUNNEL_ID,
+      'planechase.pending_plane_options': ['38f84e55-049c-441e-b4e2-1e207ab5dbe5'],
+    });
+    await h.expectHttpsError(
+      game.host.call('selectPlane', { gameId: game.gameId, planeId: ACADEMY_PLANE_ID }),
+      'invalid-argument'
+    );
+  });
+
+  it('accepts a plane from the persisted tunnel options', async () => {
+    const { game } = await startedPlanechase();
+    await h.patchGame(game.gameId, {
+      'planechase.current_plane_id': INTERPLANAR_TUNNEL_ID,
+      'planechase.pending_plane_options': [ACADEMY_PLANE_ID],
+    });
+    const res = await game.host.call('selectPlane', {
+      gameId: game.gameId,
+      planeId: ACADEMY_PLANE_ID,
+    });
+    assert.deepEqual(res, { newPlaneId: ACADEMY_PLANE_ID });
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.planechase.current_plane_id, ACADEMY_PLANE_ID);
+    assert.equal(g.planechase.pending_plane_options, undefined);
+  });
+});

--- a/functions/test/integration/callables/start-game.test.js
+++ b/functions/test/integration/callables/start-game.test.js
@@ -216,54 +216,15 @@ describe('startGame — non-treachery game modes', () => {
 });
 
 describe('startGame — player counts outside the distribution table', () => {
-  // SKIP: currently broken — see finding #F. Un-skip when functions/index.js is fixed.
-  //
-  // getRoleDistribution() falls back to the 4-player distribution (sum = 4) for
-  // any count it does not know, so a 9-player game assigns only 4 roles and the
-  // 5th player gets role `undefined`. That surfaces as an opaque
-  // `internal: Not enough identity cards for role: undefined`.
-  //
-  // Correct expectation: either a real 9-player distribution, or a clear
-  // client-facing error — never `internal`.
-  it(
-    'a 9-player game either deals a real distribution or fails with a clear error',
-    { skip: 'currently broken — see finding #F' },
-    async () => {
-      const users = await h.getUsers(9);
-      const game = await h.seedGame({ users, maxPlayers: 8 });
+  it('rejects a 9-player start with a clear client error', async () => {
+    const users = await h.getUsers(9);
+    const game = await h.seedGame({ users, maxPlayers: 8 });
 
-      let err = null;
-      try {
-        await game.host.call('startGame', { gameId: game.gameId });
-      } catch (e) {
-        err = e;
-      }
-
-      if (err) {
-        const code = String(err.code || '').replace(/^functions\//, '');
-        assert.ok(
-          ['failed-precondition', 'invalid-argument'].includes(code),
-          `expected a clear client error, got "${code}": ${err.message}`
-        );
-        const g = await h.getGame(game.gameId);
-        assert.equal(g.state, 'waiting', 'a failed start must roll back');
-        return;
-      }
-
-      const players = await h.getPlayers(game.gameId);
-      assert.equal(players.length, 9);
-      const counts = h.roleCounts(players);
-      assert.equal(
-        counts.leader + counts.guardian + counts.assassin + counts.traitor,
-        9,
-        'every player must receive a role'
-      );
-      assert.equal(counts.leader, 1, 'exactly one leader');
-      assert.equal(
-        new Set(players.map((p) => p.identity_card_id)).size,
-        9,
-        'identity cards must be unique'
-      );
-    }
-  );
+    await h.expectHttpsError(
+      game.host.call('startGame', { gameId: game.gameId }),
+      'failed-precondition'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.state, 'waiting', 'a failed start must roll back');
+  });
 });

--- a/functions/test/integration/callables/traitor-abilities.test.js
+++ b/functions/test/integration/callables/traitor-abilities.test.js
@@ -643,4 +643,16 @@ describe('resolveWearerOfMasks', () => {
       assert.equal(players[2].identity_card_id, 'assassin_02');
     }
   );
+
+  it('rejects a caller who was not originally The Wearer of Masks', async () => {
+    const game = await unveiledWearer();
+    await h.patchPlayer(game.gameId, 'p3', { original_identity_card_id: 'assassin_01' });
+    await h.expectHttpsError(
+      game.traitor.call('resolveWearerOfMasks', {
+        gameId: game.gameId,
+        chosenCardId: 'assassin_15',
+      }),
+      'failed-precondition'
+    );
+  });
 });

--- a/functions/test/integration/callables/update-game-settings.test.js
+++ b/functions/test/integration/callables/update-game-settings.test.js
@@ -88,6 +88,17 @@ describe('updateGameSettings — maxPlayers', () => {
       assert.equal(g.max_players, 8);
     });
   }
+
+  it('rejects maxPlayers below the current lobby size', async () => {
+    const users = await h.getUsers(4);
+    const game = await h.seedGame({ users, maxPlayers: 8 });
+    await h.expectHttpsError(
+      game.host.call('updateGameSettings', { gameId: game.gameId, maxPlayers: 2 }),
+      'failed-precondition'
+    );
+    const g = await h.getGame(game.gameId);
+    assert.equal(g.max_players, 8);
+  });
 });
 
 describe('updateGameSettings — gameMode', () => {


### PR DESCRIPTION
## Summary
- Confirmed by a functions red-team pass: `selectPlane` could cherry-pick any plane; `endGame` could grant ELO to UIDs not at the table; Wearer-of-Masks ran after a Puppet Master swap; `resolvePhenomenon`/`rollPlanarDie` ignored seating or game mode; `startGame` fell back to a 4-role deal for 9+ players; `updateGameSettings` could set `max_players` below the current lobby.
- Interplanar Tunnel now persists `pending_plane_options` on the game doc; `selectPlane` only accepts an offered id while the current plane is the tunnel.
- Planechase callables require `game_mode` ∈ `{planechase, treachery_planechase}` and a seated caller. `onGameFinished` uses `isTreacheryMode` so legacy null-mode games still get ELO.

## Test plan
- [x] `cd functions && npm test` (129 passing)
- [x] `cd functions && npm run test:integration` (173 passing, 0 skipped)
- [ ] Start a planechase game, hit Interplanar Tunnel, confirm only the five offered planes can be selected
- [ ] Confirm rolling the planar die in a pure Treachery game is rejected
- [ ] Confirm ending a Life Tracker game with a non-seated winner UID is rejected
- [ ] Confirm lowering max players below the seated count is rejected


Made with [Cursor](https://cursor.com)