### PR TITLE
Fix web board integrity (roles, spectators, Planechase)

### DIFF
--- a/Treachery/app/(app)/game-over/[gameId].tsx
+++ b/Treachery/app/(app)/game-over/[gameId].tsx
@@ -8,6 +8,8 @@ import { LoadingScreen } from '@/components/LoadingScreen';
 import { ROLE_COLORS, ROLE_DISPLAY_NAMES } from '@/constants/roles';
 import { colors, spacing, fonts, contentMaxWidths } from '@/constants/theme';
 import { useResponsive } from '@/hooks/useResponsive';
+import { getCard } from '@/services/cardDatabase';
+import { dealtRole, dealtIdentityCardId } from '@/models/types';
 
 export default function GameOverScreen() {
   const { gameId } = useLocalSearchParams<{ gameId: string }>();
@@ -15,7 +17,7 @@ export default function GameOverScreen() {
   const { currentUserId } = useAuth();
 
   const { isDesktop } = useResponsive();
-  const { game, players, winningTeam, identityCard, isGameFinished } = useGameBoard(
+  const { game, players, winningTeam, isGameFinished } = useGameBoard(
     gameId!,
     currentUserId,
   );
@@ -104,8 +106,10 @@ export default function GameOverScreen() {
       <View style={styles.playerList}>
         {players.map((player, index) => {
           if (isTreacheryMode) {
-            const card = identityCard(player);
-            const roleColor = player.role ? ROLE_COLORS[player.role] : colors.textSecondary;
+            const role = dealtRole(player);
+            const cardId = dealtIdentityCardId(player);
+            const card = cardId ? getCard(cardId) : undefined;
+            const roleColor = role ? ROLE_COLORS[role] : colors.textSecondary;
 
             const playerAccentColor = player.player_color || roleColor;
 
@@ -122,7 +126,7 @@ export default function GameOverScreen() {
                   </View>
                   <View style={styles.playerRight}>
                     <Text style={[styles.roleText, { color: roleColor }]}>
-                      {player.role ? ROLE_DISPLAY_NAMES[player.role] : 'Unknown'}
+                      {role ? ROLE_DISPLAY_NAMES[role] : 'Unknown'}
                     </Text>
                     {card && <Text style={styles.cardName}>{card.name}</Text>}
                   </View>

--- a/Treachery/app/(app)/game/[gameId].tsx
+++ b/Treachery/app/(app)/game/[gameId].tsx
@@ -220,6 +220,9 @@ export default function GameBoardScreen() {
   }
 
   const inspectedCard = inspectedPlayer ? identityCard(inspectedPlayer) : undefined;
+  const isEliminatedSpectator = !!currentPlayer?.is_eliminated;
+  const showPhenomenonResolver =
+    isPlanechaseActive && !isOwnDeckMode && !!currentPlane?.is_phenomenon && !tunnelOptions;
 
   return (
     <View style={styles.container}>
@@ -263,10 +266,7 @@ export default function GameBoardScreen() {
 
             {isPlanechaseActive && isChaoticAetherActive && <ChaoticAetherBanner />}
 
-            {isPlanechaseActive &&
-              !isOwnDeckMode &&
-              currentPlane?.is_phenomenon &&
-              !tunnelOptions && (
+            {showPhenomenonResolver && currentPlane && (
                 <PhenomenonOverlay
                   plane={currentPlane}
                   isPending={isPending}
@@ -274,8 +274,10 @@ export default function GameBoardScreen() {
                 />
               )}
 
-            {/* Always-visible plane card image (rotated 90° clockwise) */}
-            {isPlanechaseActive && !isOwnDeckMode && currentPlane?.image_uri && (
+            {/* Always-visible plane card image (rotated 90° clockwise).
+                Hidden while a phenomenon is waiting to resolve so the overlay
+                is not stacked under a second copy of the same card. */}
+            {isPlanechaseActive && !isOwnDeckMode && currentPlane?.image_uri && !showPhenomenonResolver && (
               <TouchableOpacity
                 style={styles.sidebarImageContainer}
                 onPress={() => setShowPlaneDetail(true)}
@@ -379,6 +381,14 @@ export default function GameBoardScreen() {
           {/* Mobile-only: chaotic aether */}
           {!isDesktop && isPlanechaseActive && isChaoticAetherActive && <ChaoticAetherBanner />}
 
+          {!isDesktop && showPhenomenonResolver && currentPlane && (
+            <PhenomenonOverlay
+              plane={currentPlane}
+              isPending={isPending}
+              onResolve={resolvePhenomenon}
+            />
+          )}
+
           {/* Ornate divider */}
           <View style={styles.ornateDividerRow}>
             <View style={styles.ornateLine} />
@@ -394,18 +404,22 @@ export default function GameBoardScreen() {
               currentUserId={currentUserId}
               activePlayerId={activePlayerId}
               onReorder={reorderSeats}
+              canReorder={!isEliminatedSpectator}
               center={
                 <>
                   <TouchableOpacity
-                    style={styles.turnButton}
+                    style={[styles.turnButton, isEliminatedSpectator && styles.buttonDisabled]}
                     onPress={advanceTurn}
+                    disabled={isEliminatedSpectator}
                     accessibilityLabel="Next turn"
                     accessibilityRole="button"
                   >
                     <Ionicons name="play-forward" size={16} color="#0d0b1a" />
                     <Text style={styles.turnButtonText}>Next Turn</Text>
                   </TouchableOpacity>
-                  <Text style={styles.tableHint}>Drag a player onto another seat to swap</Text>
+                  {!isEliminatedSpectator && (
+                    <Text style={styles.tableHint}>Drag a player onto another seat to swap</Text>
+                  )}
                 </>
               }
               renderTile={(item, state) => (
@@ -422,6 +436,7 @@ export default function GameBoardScreen() {
                   playerColor={item.player_color}
                   isDragging={state.isDragging}
                   isDropTarget={state.isDropTarget}
+                  isDisabled={isEliminatedSpectator}
                 />
               )}
             />
@@ -437,7 +452,7 @@ export default function GameBoardScreen() {
                   isUnveiledOrLeader={item.is_unveiled || item.role === 'leader'}
                   onAdjustLife={(amount) => adjustLife(item.id, amount)}
                   onViewCard={() => setInspectedPlayer(item)}
-                  isDisabled={false}
+                  isDisabled={isEliminatedSpectator}
                   onColorChange={item.user_id === currentUserId ? updatePlayerColor : undefined}
                   playerColor={item.player_color}
                   onRename={item.user_id === currentUserId ? renameCurrentPlayer : undefined}
@@ -549,7 +564,7 @@ export default function GameBoardScreen() {
       )}
 
       {/* Inspected player card modal */}
-      {inspectedCard && inspectedPlayer && (
+      {inspectedCard && inspectedPlayer && canSeeRole(inspectedPlayer) && (
         <IdentityCardDetail
           card={inspectedCard}
           player={inspectedPlayer}

--- a/Treachery/app/(app)/history.tsx
+++ b/Treachery/app/(app)/history.tsx
@@ -6,7 +6,7 @@ import { useGameHistory } from '@/hooks/useGameHistory';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { getCard } from '@/services/cardDatabase';
 import { ROLE_COLORS, ROLE_DISPLAY_NAMES } from '@/constants/roles';
-import { Game, Player, Role } from '@/models/types';
+import { Game, Player, Role, dealtRole, dealtIdentityCardId } from '@/models/types';
 import { colors, spacing, fonts, contentMaxWidths } from '@/constants/theme';
 import { useResponsive } from '@/hooks/useResponsive';
 
@@ -67,12 +67,14 @@ function GameHistoryRow({
 }) {
   const winningRole = game.winning_team as Role | null;
   const myPlayer = players.find((p) => p.user_id === currentUserId);
+  const myDealtRole = myPlayer ? dealtRole(myPlayer) : null;
+  const myDealtCardId = myPlayer ? dealtIdentityCardId(myPlayer) : null;
   const didWin = (() => {
-    if (!myPlayer?.role || !winningRole) return false;
+    if (!myDealtRole || !winningRole) return false;
     if (winningRole === 'leader') {
-      return myPlayer.role === 'leader' || myPlayer.role === 'guardian';
+      return myDealtRole === 'leader' || myDealtRole === 'guardian';
     }
-    return myPlayer.role === winningRole;
+    return myDealtRole === winningRole;
   })();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,7 +92,7 @@ function GameHistoryRow({
   };
 
   // Use role color for the card border accent
-  const borderColor = myPlayer?.role ? ROLE_COLORS[myPlayer.role] + '60' : colors.border;
+  const borderColor = myDealtRole ? ROLE_COLORS[myDealtRole] + '60' : colors.border;
 
   return (
     <View style={[styles.gameCard, { borderColor }]}>
@@ -122,7 +124,8 @@ function GameHistoryRow({
           <View style={styles.gameDivider} />
           <View style={styles.playerGrid}>
             {players.map((player) => {
-              const roleColor = player.role ? ROLE_COLORS[player.role] : colors.textSecondary;
+              const role = dealtRole(player);
+              const roleColor = role ? ROLE_COLORS[role] : colors.textSecondary;
               return (
                 <View key={player.id} style={styles.gridPlayer}>
                   <View style={[styles.gridDot, { backgroundColor: roleColor }]} />
@@ -146,15 +149,15 @@ function GameHistoryRow({
       )}
 
       {/* My role */}
-      {myPlayer?.role && (
+      {myDealtRole && (
         <View style={styles.myRoleRow}>
           <Text style={styles.myRoleLabel}>Your role:</Text>
-          <Text style={[styles.myRoleValue, { color: ROLE_COLORS[myPlayer.role] }]}>
-            {ROLE_DISPLAY_NAMES[myPlayer.role]}
+          <Text style={[styles.myRoleValue, { color: ROLE_COLORS[myDealtRole] }]}>
+            {ROLE_DISPLAY_NAMES[myDealtRole]}
           </Text>
-          {myPlayer.identity_card_id && (
+          {myDealtCardId && (
             <Text style={styles.myCardName}>
-              ({getCard(myPlayer.identity_card_id)?.name ?? ''})
+              ({getCard(myDealtCardId)?.name ?? ''})
             </Text>
           )}
         </View>

--- a/Treachery/src/components/PlayerTile.tsx
+++ b/Treachery/src/components/PlayerTile.tsx
@@ -64,6 +64,8 @@ export interface PlayerTileProps {
   isDropTarget?: boolean;
   /** 'tv' is a larger variant for a future spectator screen: bigger life number, no controls. */
   size?: 'normal' | 'tv';
+  /** Spectator / eliminated viewer: life buttons stay visible but do nothing. */
+  isDisabled?: boolean;
 }
 
 export function PlayerTile({
@@ -71,7 +73,7 @@ export function PlayerTile({
   isCurrentUser,
   isActiveTurn,
   canSeeRole,
-  isUnveiledOrLeader,
+  isUnveiledOrLeader: _isUnveiledOrLeader,
   onAdjustLife,
   onViewCard,
   onRename,
@@ -80,6 +82,7 @@ export function PlayerTile({
   isDragging,
   isDropTarget,
   size = 'normal',
+  isDisabled,
 }: PlayerTileProps) {
   const isTv = size === 'tv';
 
@@ -89,7 +92,7 @@ export function PlayerTile({
   const visibleRole = canSeeRole ? player.role : null;
   const roleColor = visibleRole ? ROLE_COLORS[visibleRole] : colors.textSecondary;
   const effectiveColor = player.player_color || playerColor;
-  const canInspectCard = isUnveiledOrLeader && !isCurrentUser && !isTv && !!onViewCard;
+  const canInspectCard = canSeeRole && !isCurrentUser && !isTv && !!onViewCard;
 
   // The tv variant is a read-only spectator screen — no editing your own seat on it.
   const showOwnControls = isCurrentUser && !isTv;
@@ -240,6 +243,7 @@ export function PlayerTile({
         {!player.is_eliminated && !isTv && (
           <Pressable
             onPress={() => onAdjustLife(-1)}
+            disabled={isDisabled}
             style={({ hovered, pressed }: WebPressableState) => [
               styles.lifeButton,
               hovered && styles.lifeButtonDecrHovered,
@@ -267,6 +271,7 @@ export function PlayerTile({
         {!player.is_eliminated && !isTv && (
           <Pressable
             onPress={() => onAdjustLife(1)}
+            disabled={isDisabled}
             style={({ hovered, pressed }: WebPressableState) => [
               styles.lifeButton,
               hovered && styles.lifeButtonIncrHovered,

--- a/Treachery/src/components/RoundTable.tsx
+++ b/Treachery/src/components/RoundTable.tsx
@@ -41,6 +41,8 @@ export interface RoundTableProps {
    * expressed in SHARED order (rotation is undone before this is called).
    */
   onReorder: (orderedPlayerIds: string[]) => void;
+  /** When false, seats stay put (eliminated spectators cannot restack the table). */
+  canReorder?: boolean;
   /** Renders one player's tile. `isDragging`/`isDropTarget` drive its visuals. */
   renderTile: (
     player: Player,
@@ -55,6 +57,7 @@ export function RoundTable({
   currentUserId,
   activePlayerId,
   onReorder,
+  canReorder = true,
   renderTile,
   center,
 }: RoundTableProps) {
@@ -116,7 +119,20 @@ export function RoundTable({
       </View>
 
       {size.width > 0 &&
-        seated.map((player, index) => (
+        seated.map((player, index) => {
+          const tile = renderTile(player, {
+            isActiveTurn: player.id === activePlayerId,
+            isDragging: draggingId === player.id,
+            isDropTarget: dropTargetId === player.id,
+          });
+          if (!canReorder) {
+            return (
+              <View key={player.id} style={[styles.seat, seatOrigin(index)]}>
+                {tile}
+              </View>
+            );
+          }
+          return (
           <DraggableSeat
             key={player.id}
             index={index}
@@ -175,13 +191,10 @@ export function RoundTable({
               onReorder(shared.map((p) => p.id));
             }}
           >
-            {renderTile(player, {
-              isActiveTurn: player.id === activePlayerId,
-              isDragging: draggingId === player.id,
-              isDropTarget: dropTargetId === player.id,
-            })}
+            {tile}
           </DraggableSeat>
-        ))}
+          );
+        })}
     </View>
   );
 }

--- a/Treachery/src/models/types.ts
+++ b/Treachery/src/models/types.ts
@@ -90,11 +90,23 @@ export interface Player {
   player_color: string | null;
   commander_name: string | null;
   original_identity_card_id?: string | null;
+  // Dealt role before Puppet Master / Wearer swaps. Absent until a swap.
+  original_role?: Role | null;
   is_face_down?: boolean;
   // Once-per-game guard written by the traitor ability resolvers in
   // functions/index.js. Never initialized on the player doc, so absent
   // means the ability has not been used yet.
   ability_resolved?: boolean;
+}
+
+/** Role this player was dealt, ignoring mid-game identity swaps. */
+export function dealtRole(player: Player): Role | null {
+  return player.original_role ?? player.role;
+}
+
+/** Identity card this player was dealt, ignoring mid-game identity swaps. */
+export function dealtIdentityCardId(player: Player): string | null {
+  return player.original_identity_card_id ?? player.identity_card_id;
 }
 
 export interface IdentityCard {


### PR DESCRIPTION
## Summary
- Game-over and history show **dealt** roles/cards (`original_role` / `original_identity_card_id`) so Puppet Master and Wearer swaps no longer rewrite the recap.
- Eliminated spectators can no longer adjust life, advance the turn, or drag-reorder seats; card inspect uses `canSeeRole` (Puppet Master peeks work; hidden cards stay closed).
- Mobile/tablet Planechase now renders `PhenomenonOverlay` so phenomena can be resolved off desktop. The sidebar plane image hides while that overlay is up.

## Test plan
- [ ] Unveil Wearer/Puppet Master, swap identities, finish the game — recap and History show original dealt roles, not the swapped ones.
- [ ] Eliminate yourself mid-game: life +/- disabled, Next Turn disabled, seats not draggable; remaining players still play.
- [ ] On a phone-width window, roll onto a phenomenon and confirm Resolve is available (not desktop-only).
- [ ] Inspect an unveiled opponent and a Puppet Master face-down peek; a hidden role should not open a card modal.


Made with [Cursor](https://cursor.com)