### PR TITLE
Fix iOS traitor ability retry and sheet dismiss

### DIFF
--- a/Treachery-iOS/Treachery-iOS/Home/ActionBar.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/ActionBar.swift
@@ -40,6 +40,16 @@ struct ActionBar: View {
                 }
             }
 
+            if viewModel.resolvableAbility != nil {
+                Button("Activate Ability") {
+                    viewModel.presentAbilityResolver()
+                }
+                .buttonStyle(MtgPrimaryButtonStyle(isDisabled: viewModel.isPending))
+                .disabled(viewModel.isPending)
+                .padding(.horizontal)
+                .accessibilityLabel("Activate traitor ability")
+                .accessibilityHint("Opens the ability you unveiled. You can skip and come back later.")
+            }
         }
         .padding()
     }

--- a/Treachery-iOS/Treachery-iOS/Home/GameBoardView.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/GameBoardView.swift
@@ -334,7 +334,9 @@ struct GameBoardView: View {
                 showWinnerSelection = false
             }
         }
-        .sheet(item: $viewModel.pendingAbilityResolution) { resolution in
+        .sheet(item: $viewModel.pendingAbilityResolution, onDismiss: {
+            viewModel.dismissAbility()
+        }) { resolution in
             switch resolution.abilityType {
             case .metamorph:
                 MetamorphAbilitySheet(

--- a/Treachery-iOS/Treachery-iOS/Home/GameBoardViewModel.swift
+++ b/Treachery-iOS/Treachery-iOS/Home/GameBoardViewModel.swift
@@ -50,6 +50,18 @@ final class GameBoardViewModel: ObservableObject {
         return players.first { $0.userId == userId }
     }
 
+    /// Unveiled traitor ability that has not been resolved yet.
+    /// Decline/Skip leaves `ability_resolved` unset on the server, so this
+    /// stays non-nil and the Action Bar can reopen the sheet.
+    var resolvableAbility: ExecutableAbility? {
+        guard let player = currentPlayer,
+              player.isUnveiled,
+              !player.isEliminated,
+              !player.abilityResolved,
+              let cardId = player.identityCardId else { return nil }
+        return ExecutableAbility(cardId: cardId)
+    }
+
     var currentIdentityCard: IdentityCard? {
         guard let cardId = currentPlayer?.identityCardId else { return nil }
         return cardDatabase.card(withId: cardId)
@@ -260,15 +272,25 @@ final class GameBoardViewModel: ObservableObject {
         isPending = false
     }
 
-    private func checkForAbilityTrigger(player: Player) {
-        guard let cardId = player.identityCardId,
-              let ability = ExecutableAbility(cardId: cardId) else { return }
+    func presentAbilityResolver() {
+        guard let player = currentPlayer, resolvableAbility != nil else { return }
+        pendingAbilityResolution = makeAbilityResolution(for: player)
+    }
 
-        let resolution: AbilityResolution
+    private func checkForAbilityTrigger(player: Player) {
+        guard !player.abilityResolved else { return }
+        guard ExecutableAbility(cardId: player.identityCardId ?? "") != nil else { return }
+        pendingAbilityResolution = makeAbilityResolution(for: player)
+    }
+
+    private func makeAbilityResolution(for player: Player) -> AbilityResolution? {
+        guard let cardId = player.identityCardId,
+              let ability = ExecutableAbility(cardId: cardId) else { return nil }
+
         switch ability {
         case .metamorph:
             let eliminated = players.filter { $0.isEliminated && $0.role != .leader && $0.userId != player.userId }
-            resolution = AbilityResolution(
+            return AbilityResolution(
                 abilityType: .metamorph,
                 actingPlayerId: player.id,
                 candidateCards: [],
@@ -276,21 +298,20 @@ final class GameBoardViewModel: ObservableObject {
             )
         case .puppetMaster:
             let otherAlive = players.filter { !$0.isEliminated && $0.userId != player.userId }
-            resolution = AbilityResolution(
+            return AbilityResolution(
                 abilityType: .puppetMaster,
                 actingPlayerId: player.id,
                 candidateCards: [],
                 candidatePlayers: otherAlive
             )
         case .wearerOfMasks:
-            resolution = AbilityResolution(
+            return AbilityResolution(
                 abilityType: .wearerOfMasks,
                 actingPlayerId: player.id,
                 candidateCards: [],
                 candidatePlayers: []
             )
         }
-        pendingAbilityResolution = resolution
     }
 
     // MARK: - Leave Game (via Cloud Function)

--- a/Treachery-iOS/Treachery-iOS/Models/Player.swift
+++ b/Treachery-iOS/Treachery-iOS/Models/Player.swift
@@ -22,6 +22,7 @@ struct Player: Codable, Identifiable, Equatable {
     var commanderName: String?
     var originalIdentityCardId: String?
     var isFaceDown: Bool
+    var abilityResolved: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -38,6 +39,7 @@ struct Player: Codable, Identifiable, Equatable {
         case commanderName = "commander_name"
         case originalIdentityCardId = "original_identity_card_id"
         case isFaceDown = "is_face_down"
+        case abilityResolved = "ability_resolved"
     }
 
     // Custom decoder: uses decodeIfPresent for 'id' to handle documents
@@ -50,7 +52,14 @@ struct Player: Codable, Identifiable, Equatable {
         orderId = try container.decode(Int.self, forKey: .orderId)
         userId = try container.decode(String.self, forKey: .userId)
         displayName = try container.decode(String.self, forKey: .displayName)
-        role = try container.decodeIfPresent(Role.self, forKey: .role)
+        // Unknown role strings become nil instead of failing the whole player
+        // decode (Android's Role.fromValue() does the same). FirestoreManager
+        // uses try?, so a throw here would drop the player from the board.
+        if let rawRole = try container.decodeIfPresent(String.self, forKey: .role) {
+            role = Role(rawValue: rawRole)
+        } else {
+            role = nil
+        }
         identityCardId = try container.decodeIfPresent(String.self, forKey: .identityCardId)
         lifeTotal = try container.decode(Int.self, forKey: .lifeTotal)
         isEliminated = try container.decode(Bool.self, forKey: .isEliminated)
@@ -60,6 +69,7 @@ struct Player: Codable, Identifiable, Equatable {
         commanderName = try container.decodeIfPresent(String.self, forKey: .commanderName)
         originalIdentityCardId = try container.decodeIfPresent(String.self, forKey: .originalIdentityCardId)
         isFaceDown = try container.decodeIfPresent(Bool.self, forKey: .isFaceDown) ?? false
+        abilityResolved = try container.decodeIfPresent(Bool.self, forKey: .abilityResolved) ?? false
     }
 
     init(
@@ -76,7 +86,8 @@ struct Player: Codable, Identifiable, Equatable {
         playerColor: String? = nil,
         commanderName: String? = nil,
         originalIdentityCardId: String? = nil,
-        isFaceDown: Bool = false
+        isFaceDown: Bool = false,
+        abilityResolved: Bool = false
     ) {
         self.id = id
         self.orderId = orderId
@@ -92,5 +103,6 @@ struct Player: Codable, Identifiable, Equatable {
         self.commanderName = commanderName
         self.originalIdentityCardId = originalIdentityCardId
         self.isFaceDown = isFaceDown
+        self.abilityResolved = abilityResolved
     }
 }

--- a/Treachery-iOS/Treachery-iOSTests/GameBoardViewModelTests.swift
+++ b/Treachery-iOS/Treachery-iOSTests/GameBoardViewModelTests.swift
@@ -199,4 +199,62 @@ struct GameBoardViewModelTests {
         let vm = makeVM(game: game)
         #expect(vm.dieRollCost == 1)
     }
+
+    // MARK: - Traitor Ability Retry
+
+    private func abilityPlayer(
+        cardId: String = "traitor_07",
+        isUnveiled: Bool = true,
+        isEliminated: Bool = false,
+        abilityResolved: Bool = false
+    ) -> Player {
+        Player(
+            id: "p1", orderId: 1, userId: "u1", displayName: "Alice",
+            role: .traitor, identityCardId: cardId, lifeTotal: 40,
+            isEliminated: isEliminated, isUnveiled: isUnveiled, joinedAt: Date(),
+            abilityResolved: abilityResolved
+        )
+    }
+
+    @Test func resolvableAbilityWhenUnveiledMetamorph() {
+        let vm = makeVM(players: [abilityPlayer()])
+        #expect(vm.resolvableAbility == .metamorph)
+    }
+
+    @Test func resolvableAbilityWhenUnveiledPuppetMaster() {
+        let vm = makeVM(players: [abilityPlayer(cardId: "traitor_09")])
+        #expect(vm.resolvableAbility == .puppetMaster)
+    }
+
+    @Test func resolvableAbilityNilOnceResolved() {
+        let vm = makeVM(players: [abilityPlayer(abilityResolved: true)])
+        #expect(vm.resolvableAbility == nil)
+    }
+
+    @Test func resolvableAbilityNilWhenStillVeiled() {
+        let vm = makeVM(players: [abilityPlayer(isUnveiled: false)])
+        #expect(vm.resolvableAbility == nil)
+    }
+
+    @Test func resolvableAbilityNilWhenEliminated() {
+        let vm = makeVM(players: [abilityPlayer(isEliminated: true)])
+        #expect(vm.resolvableAbility == nil)
+    }
+
+    @Test func resolvableAbilityNilForNonAbilityCard() {
+        let vm = makeVM(players: [abilityPlayer(cardId: "assassin_01")])
+        #expect(vm.resolvableAbility == nil)
+    }
+
+    @Test func presentAbilityResolverOpensSheet() {
+        let vm = makeVM(players: [abilityPlayer()])
+        vm.presentAbilityResolver()
+        #expect(vm.pendingAbilityResolution?.abilityType == .metamorph)
+    }
+
+    @Test func presentAbilityResolverDoesNothingWhenResolved() {
+        let vm = makeVM(players: [abilityPlayer(abilityResolved: true)])
+        vm.presentAbilityResolver()
+        #expect(vm.pendingAbilityResolution == nil)
+    }
 }

--- a/Treachery-iOS/Treachery-iOSTests/ModelDecodingTests.swift
+++ b/Treachery-iOS/Treachery-iOSTests/ModelDecodingTests.swift
@@ -125,6 +125,7 @@ struct PlayerDecodingTests {
         #expect(player.lifeTotal == 40)
         #expect(player.isEliminated == false)
         #expect(player.isUnveiled == true)
+        #expect(player.abilityResolved == false)
     }
 
     @Test func decodesPlayerWithNilOptionals() throws {
@@ -145,6 +146,25 @@ struct PlayerDecodingTests {
         #expect(player.identityCardId == nil)
         #expect(player.playerColor == nil)
         #expect(player.commanderName == nil)
+        #expect(player.abilityResolved == false)
+    }
+
+    @Test func decodesAbilityResolvedTrue() throws {
+        let json = Data("""
+        {
+            "id": "p1",
+            "order_id": 0,
+            "user_id": "u1",
+            "display_name": "Bob",
+            "life_total": 40,
+            "is_eliminated": false,
+            "is_unveiled": true,
+            "joined_at": 1000000,
+            "ability_resolved": true
+        }
+        """.utf8)
+        let player = try decoder.decode(Player.self, from: json)
+        #expect(player.abilityResolved == true)
     }
 
     @Test func playerEquality() {

--- a/Treachery-iOS/Treachery-iOSTests/ModelRobustnessTests.swift
+++ b/Treachery-iOS/Treachery-iOSTests/ModelRobustnessTests.swift
@@ -110,13 +110,9 @@ struct PlayerRobustnessTests {
             "joined_at": 1000000
         }
         """.utf8)
-        // Role? with an unknown raw value should fail to decode,
-        // and since it's Optional via decodeIfPresent, it should be nil
-        // Note: decodeIfPresent actually throws for invalid values (not missing ones),
-        // so an unknown role string WILL throw. This documents that behavior.
-        #expect(throws: DecodingError.self) {
-            _ = try decoder.decode(Player.self, from: json)
-        }
+        let player = try decoder.decode(Player.self, from: json)
+        #expect(player.role == nil)
+        #expect(player.displayName == "Alice")
     }
 
     @Test func encodeThenDecodeRoundTrip() throws {


### PR DESCRIPTION
## Summary
- iOS now tracks `ability_resolved` and shows **Activate Ability** after Unveil, matching Android. Skip/Decline no longer permanently traps Metamorph or Puppet Master.
- Ability sheet swipe-dismiss clears `pendingAbilityResolution` so the board is not stuck re-presenting.
- Unknown `role` strings decode as `nil` instead of dropping that player from the listener.

## Test plan
- [ ] Deal The Metamorph, unveil before anyone is eliminated, tap Skip. Eliminate a non-leader opponent. Confirm **Activate Ability** appears and the copy sheet works.
- [ ] Same flow for Puppet Master after Decline.
- [ ] Unveil Wearer of Masks, swipe the sheet down, confirm play continues (sheet does not immediately re-open in a loop).
- [ ] After a successful resolve, Activate Ability stays gone.


Made with [Cursor](https://cursor.com)