### PR TITLE
Unbreak game creation on shipped builds; fix history win/loss

### DIFF
--- a/.github/workflows/deploy-internal-test.yml
+++ b/.github/workflows/deploy-internal-test.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: deploy-android-internal
-  cancel-in-progress: true
+  # Queue rather than abort: a cancelled run can still have uploaded a bundle
+  # to the Play track, so aborting mid-flight makes the track's contents
+  # ambiguous. Matches deploy-playstore.
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,13 @@ on:
 
 concurrency:
   group: deploy-staging
-  cancel-in-progress: true
+  # Queue, never abort. Cancelling mid-`firebase deploy` kills the Cloud Build
+  # jobs it has in flight, and a later run then reports every function as
+  # "Failed to update" with CANCELLED builds — which is how four merges in
+  # quick succession took staging down. A half-cancelled functions deploy can
+  # also leave the project on a mix of old and new code. Matches
+  # deploy-web-production and deploy-playstore.
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: deploy-testflight
-  cancel-in-progress: true
+  # Queue rather than abort: a cancelled run can still have uploaded a build to
+  # App Store Connect, and killing one mid-upload burns the build number for
+  # everyone. Matches deploy-appstore.
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/Treachery/app/(app)/history.tsx
+++ b/Treachery/app/(app)/history.tsx
@@ -69,12 +69,18 @@ function GameHistoryRow({
   const myPlayer = players.find((p) => p.user_id === currentUserId);
   const myDealtRole = myPlayer ? dealtRole(myPlayer) : null;
   const myDealtCardId = myPlayer ? dealtIdentityCardId(myPlayer) : null;
+  // Win/loss must be decided from the CURRENT role, not the dealt one: that is
+  // what the server scored the game with (onGameFinished awards ELO from
+  // player.role), so after a Puppet Master swap the team you actually won with
+  // is the one you ended on. dealtRole is for display only — using it here
+  // showed "Defeat" on games the server had recorded as a win.
+  const myScoredRole = myPlayer?.role ?? null;
   const didWin = (() => {
-    if (!myDealtRole || !winningRole) return false;
+    if (!myScoredRole || !winningRole) return false;
     if (winningRole === 'leader') {
-      return myDealtRole === 'leader' || myDealtRole === 'guardian';
+      return myScoredRole === 'leader' || myScoredRole === 'guardian';
     }
-    return myDealtRole === winningRole;
+    return myScoredRole === winningRole;
   })();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/firestore-tests/test/games.test.js
+++ b/firestore-tests/test/games.test.js
@@ -128,6 +128,35 @@ describe("games/{gameId}", () => {
         )
       );
     });
+
+    // Rules ship independently of app releases, so the create bounds have to
+    // accept what the CURRENT App Store / Play build writes, not what today's
+    // UI offers. v1.1.0 creates the game doc directly (it predates the
+    // createGame callable) with max_players 12 for non-treachery modes and any
+    // 20-60 life in steps of 5. Tightening these to the callable's bounds
+    // returned PERMISSION_DENIED on every installed binary and killed
+    // Planechase / Life Tracker creation outright.
+    it("still lets a shipped v1.1.0 build create a 12-player non-treachery game", async () => {
+      const db = await authedDb(OUTSIDER);
+      await assertSucceeds(
+        setDoc(
+          doc(db, "games", "game_legacy_cap"),
+          gameDoc(OUTSIDER, { game_mode: "planechase", max_players: 12 })
+        )
+      );
+    });
+
+    for (const life of [35, 45, 55, 60]) {
+      it(`still lets a shipped v1.1.0 build create a game with ${life} starting life`, async () => {
+        const db = await authedDb(OUTSIDER);
+        await assertSucceeds(
+          setDoc(
+            doc(db, "games", `game_legacy_life_${life}`),
+            gameDoc(OUTSIDER, { starting_life: life })
+          )
+        );
+      });
+    }
   });
 
   // ─── update: host settings ───────────────────────────────────────

--- a/firestore.rules
+++ b/firestore.rules
@@ -176,6 +176,26 @@ service cloud.firestore {
       return rarity in ['uncommon', 'rare', 'mythic', 'special'];
     }
 
+    // Wider than isValidStartingLife on purpose — see isValidClientGameCreate.
+    function isLegacyStartingLife(life) {
+      return life in [20, 25, 30, 35, 40, 45, 50, 55, 60];
+    }
+
+    // These bounds must tolerate what SHIPPED builds actually emit, which is
+    // wider than what the createGame callable accepts. v1.1.0 — the current
+    // App Store and Play build — creates the game document directly (it
+    // predates the callable) with max_players 12 for non-treachery modes and
+    // any 20-60 life in steps of 5. Rules deploy independently of app
+    // releases, so validating against the callable's tighter bounds would
+    // return PERMISSION_DENIED on every installed binary the moment this file
+    // shipped, killing Planechase and Life Tracker creation outright.
+    //
+    // The security-relevant clauses are host_id / state / player_ids: they
+    // stop a hostile create from seating other uids (which would grant them
+    // player-doc reads, and roles once the game starts). The numeric bounds
+    // are hygiene, so they mirror real client output rather than current UI.
+    // New clients go through createGame, which still enforces 2-8 and
+    // {20,25,30,40,50}.
     function isValidClientGameCreate() {
       let d = request.resource.data;
       return d.host_id == request.auth.uid
@@ -184,8 +204,8 @@ service cloud.firestore {
         && d.player_ids[0] == request.auth.uid
         && d.max_players is int
         && d.max_players >= 2
-        && d.max_players <= 8
-        && isValidStartingLife(d.starting_life)
+        && d.max_players <= 12
+        && isLegacyStartingLife(d.starting_life)
         && isValidGameMode(d.game_mode)
         && (!('max_traitor_rarity' in d) || isValidTraitorRarity(d.max_traitor_rarity));
     }


### PR DESCRIPTION
Two regressions introduced by #109 and #111, surfaced by an adversarial review pass that completed after both were merged.

## 1. #109 denied game creation on every installed binary (blocker)

`v1.1.0` — the current App Store and Play build — predates the `createGame` callable and writes the game document **directly**:

- `v1.1.0:.../CreateGameViewModel.swift:21` → `max_players = includesTreachery ? 8 : 12`
- `v1.1.0:.../CreateGameView.swift:48` → life stepper `in: 20...60, step: 5`

`isValidClientGameCreate()` validated against the *callable's* bounds (`2-8`, `{20,25,30,40,50}`), so from a shipped binary:

- **every Planechase and Life Tracker create** → `PERMISSION_DENIED` (writes `max_players: 12`)
- **35 / 45 / 55 / 60 life** → `PERMISSION_DENIED` in the other two modes

Firestore rules deploy independently of app releases, so nothing gated this on a client version. Production was not yet affected — `firestore:rules` only reaches prod via `deploy-web-production`, which fires on `release: published` — but publishing any release would have shipped it.

The create bounds now mirror what real clients emit. **The security-relevant clauses are unchanged**: `host_id`, `state`, and `player_ids.size() == 1 && player_ids[0] == uid` still prevent a hostile create from seating other uids, which is the clause that would otherwise grant player-doc reads and roles after the deal. The numeric bounds were always hygiene, not security, and new clients still go through `createGame`, which keeps the tighter product bounds.

Adds regression tests for the legacy payload shapes — no test previously exercised a v1.1.0-shaped create, which is why CI was green.

## 2. #111 mislabelled history after a Puppet Master swap

#111 correctly moved *display* onto the dealt role, but also moved `didWin` there. `onGameFinished` scores the game and awards ELO from `player.role` (functions/index.js:2217) — the **current** role — so a swapped player saw "Defeat" on a game the server had recorded as a win and paid ELO for.

Win/loss reads the scored role again; dealt roles remain for display, which is what #111 was for.

## Test plan

- [ ] `firestore-tests` green, including the four new legacy-create cases
- [ ] From a build that writes the game doc directly, create a Planechase game — succeeds
- [ ] Create a game with 45 starting life — succeeds
- [ ] Win a game as a Puppet Master who swapped into another team; History shows Victory, matching the ELO awarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)