### PR TITLE
Make every CI suite a mergeable-blocking check

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -1,21 +1,56 @@
 name: CI (Android)
 
+# Always triggers (no paths filter): "Android App" is a REQUIRED status
+# check, and a required check whose workflow never runs wedges the PR on
+# "Expected". The cheap `changes` job below detects whether Android code
+# actually changed; when it didn't, the build job is skipped — and a
+# skipped job satisfies required checks.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "TreacheryAndroid/**"
-      # Self-trigger: a PR that only edits this workflow should still run it.
-      - ".github/workflows/ci-android.yml"
+
+permissions:
+  contents: read
 
 concurrency:
   group: ci-android-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Android changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      android: ${{ steps.filter.outputs.changed }}
+    steps:
+      # fetch-depth 2: the pull_request checkout is the test merge commit;
+      # depth 2 brings in both parents, and HEAD^1 is the base branch tip,
+      # so `git diff HEAD^1 HEAD` is exactly the PR's net effect.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - id: filter
+        name: Diff against base
+        run: |
+          # Fail open: if the diff can't be computed, run the build rather
+          # than silently skipping a required gate.
+          if ! FILES=$(git diff --name-only HEAD^1 HEAD); then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "diff failed — running the full job" >&2
+            exit 0
+          fi
+          if echo "$FILES" | grep -qE '^(TreacheryAndroid/|\.github/workflows/ci-android\.yml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Android App ──────────────────────────────────────
   android-app:
     name: Android App
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -45,8 +80,8 @@ jobs:
 
       # testDebugUnitTest already implies both compiles; they are listed
       # explicitly so the log shows exactly which gate failed.
-      - name: Compile and run unit tests
-        run: ./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin testDebugUnitTest --no-daemon
+      - name: Compile, lint, and run unit tests
+        run: ./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin :app:lintDebug testDebugUnitTest --no-daemon
 
       - name: Upload test reports
         if: failure()
@@ -54,7 +89,7 @@ jobs:
         with:
           name: android-test-reports-${{ github.run_id }}
           path: |
-            TreacheryAndroid/app/build/reports/tests/
+            TreacheryAndroid/app/build/reports/
             TreacheryAndroid/app/build/test-results/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -1,12 +1,16 @@
 name: CI (iOS)
 
+# Always triggers (no paths filter): "iOS App" is a REQUIRED status check,
+# and a required check whose workflow never runs wedges the PR on
+# "Expected". The cheap ubuntu `changes` job detects whether iOS code
+# actually changed; when it didn't, the macOS job is skipped — a skipped
+# job satisfies required checks, and no macOS minutes are spent.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "Treachery-iOS/**"
-      # Self-trigger: a PR that only edits this workflow should still run it.
-      - ".github/workflows/ci-ios.yml"
+
+permissions:
+  contents: read
 
 concurrency:
   group: ci-ios-${{ github.head_ref }}
@@ -15,9 +19,40 @@ concurrency:
 # GoogleService-Info.plist is tracked, so the build needs no secret
 # injection — this workflow references no secrets and runs on fork PRs.
 jobs:
+  changes:
+    name: Detect iOS changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ios: ${{ steps.filter.outputs.changed }}
+    steps:
+      # fetch-depth 2: the pull_request checkout is the test merge commit;
+      # depth 2 brings in both parents, and HEAD^1 is the base branch tip,
+      # so `git diff HEAD^1 HEAD` is exactly the PR's net effect.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - id: filter
+        name: Diff against base
+        run: |
+          # Fail open: if the diff can't be computed, run the build rather
+          # than silently skipping a required gate.
+          if ! FILES=$(git diff --name-only HEAD^1 HEAD); then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "diff failed — running the full job" >&2
+            exit 0
+          fi
+          if echo "$FILES" | grep -qE '^(Treachery-iOS/|\.swiftlint\.yml|\.github/workflows/ci-ios\.yml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── iOS App ──────────────────────────────────────────
   ios-app:
     name: iOS App
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-15
     timeout-minutes: 40
     defaults:
@@ -31,6 +66,13 @@ jobs:
           LATEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
           echo "Using $LATEST_XCODE"
           sudo xcode-select -s "$LATEST_XCODE/Contents/Developer"
+
+      # Config lives at the repo root (.swiftlint.yml) with repo-relative
+      # included paths, so lint runs from the root. Non-strict: errors fail,
+      # warnings don't — the codebase is warning-clean enough to keep useful.
+      - name: SwiftLint
+        working-directory: .
+        run: swiftlint lint --quiet --reporter github-actions-logging
 
       # Package.resolved is gitignored, so key on the pbxproj (it pins the
       # Firebase version requirement). Without this cache, Firebase SPM

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -70,9 +70,13 @@ jobs:
       # Config lives at the repo root (.swiftlint.yml) with repo-relative
       # included paths, so lint runs from the root. Non-strict: errors fail,
       # warnings don't — the codebase is warning-clean enough to keep useful.
+      # The macos runner images stopped preinstalling swiftlint, so install
+      # the bottle first (~30s).
       - name: SwiftLint
         working-directory: .
-        run: swiftlint lint --quiet --reporter github-actions-logging
+        run: |
+          command -v swiftlint >/dev/null || brew install -q swiftlint
+          swiftlint lint --quiet --reporter github-actions-logging
 
       # Package.resolved is gitignored, so key on the pbxproj (it pins the
       # Firebase version requirement). Without this cache, Firebase SPM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+# CI only reads the repo; nothing here writes releases, comments, or
+# packages, so drop the default write-scoped token.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.head_ref }}
   cancel-in-progress: true
@@ -13,6 +18,7 @@ jobs:
   web-app:
     name: Web App
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: Treachery
@@ -40,6 +46,7 @@ jobs:
   functions:
     name: Cloud Functions
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: functions
@@ -76,7 +83,7 @@ jobs:
           cache: npm
           cache-dependency-path: functions/package-lock.json
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -108,7 +115,7 @@ jobs:
           cache: npm
           cache-dependency-path: firestore-tests/package-lock.json
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -138,7 +145,7 @@ jobs:
             Treachery/package-lock.json
             functions/package-lock.json
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,9 @@ disabled_rules:
   - unused_closure_parameter
   - static_over_final_class
   - empty_string
+  # "Puppet Master" is the printed name of an MTG Treachery identity card;
+  # every identifier touching that card trips this rule permanently.
+  - inclusive_language
 
 opt_in_rules:
   - closure_end_indentation


### PR DESCRIPTION
## Why

Branch protection requires only 2 of 8 checks — `Web App` and `Cloud Functions`. Firestore Rules, the integration suite, Playwright, and both native jobs are advisory, which is how a Compose compile break and the #109 rules regression each merged while their suites were red-capable. This PR makes requiring all 7 safe; the ruleset flip happens after merge.

## The path-filter problem

A required check whose workflow never triggers wedges the PR on "Expected" forever. So `ci-ios` / `ci-android` now **always trigger**, with a cheap ubuntu `changes` job (native `git diff HEAD^1 HEAD` against the merge commit's base parent — no third-party actions) gating the heavy job. PRs that don't touch native code report the job as **skipped**, which satisfies required checks, costs ~30s of ubuntu time, and spends no macOS minutes. The filter fails open: if the diff can't be computed, the build runs.

## Also in here

- **SwiftLint finally runs** — `.swiftlint.yml` existed with nothing enforcing it. Non-strict (errors fail, warnings don't); validated locally: the codebase exits 0. `inclusive_language` is disabled with a comment — "Puppet Master" is the printed card name, and five permanent false-positive warnings train people to ignore lint output.
- **Android `lintDebug`** added to the gradle gate — validated locally, passes.
- **`permissions: contents: read`** on all three CI workflows — they only read the repo; no reason to hand them the default write-scoped token (fork-PR hardening).
- **Timeouts** on `web-app` (15m) and `functions` (10m) — every other job had one.
- **`setup-java` v4→v5** in ci.yml, matching the deploy workflows.
- Failure-artifact upload for Android test/lint reports.

## After merge

Update ruleset `Protect main` (14389092) to require: Web App, Cloud Functions, Cloud Functions (integration), Firestore Rules, Web E2E (Playwright), iOS App, Android App. **Order matters** — flipping the ruleset before this merges would wedge every non-native PR.

## Test plan
- [ ] This PR itself exercises both `changes` jobs (it touches both workflow files → both native jobs RUN)
- [ ] All 7 suites green
- [ ] A follow-up docs-only PR should show iOS App / Android App as skipped, not pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)