### PR TITLE
Stop the Round Table drag from eating sloppy life-button taps

### DIFF
--- a/Treachery/e2e/round-table.spec.ts
+++ b/Treachery/e2e/round-table.spec.ts
@@ -124,3 +124,39 @@ test('a tap on the life buttons is not treated as a drag', async ({ browser }) =
   // ...and the seating did not move.
   expect((await seatOrder(host.page, gameId)).join(',')).toBe(before.join(','));
 });
+
+// Regression: a press that slides a few pixels (trackpad twitch, touch) used
+// to cross DraggableSeat's 6px slop, capture the pointer away from the
+// Pressable, and silently eat the tap — no error, no life change, perceived
+// as lag. handlePointerDown now refuses to arm a drag from a button.
+test('a sloppy press on a life button still registers', async ({ browser }) => {
+  const { players, gameId, host } = await setupSeededGame(browser, [
+    'leader',
+    'assassin',
+    'assassin',
+    'traitor',
+  ]);
+  const before = await seatOrder(host.page, gameId);
+  const target = players[2];
+
+  const plus = host.page.getByRole('button', { name: `Increase ${target.name} life` });
+  const box = await plus.boundingBox();
+  if (!box) throw new Error('life button not visible');
+
+  // Press, slide 8px (past the 6px drag slop), release — on the button.
+  await host.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await host.page.mouse.down();
+  await host.page.mouse.move(box.x + box.width / 2 + 8, box.y + box.height / 2 + 3, { steps: 4 });
+  await host.page.mouse.up();
+
+  // The tap must land...
+  await expect
+    .poll(async () => {
+      const docs = await fetchPlayerDocs(host.page, gameId);
+      return docs.find((d) => d.user_id === target.userId)?.life_total;
+    }, { timeout: 10_000 })
+    .toBeGreaterThan(40);
+
+  // ...without the slide being read as a seat drag.
+  expect((await seatOrder(host.page, gameId)).join(',')).toBe(before.join(','));
+});

--- a/Treachery/src/components/RoundTable.tsx
+++ b/Treachery/src/components/RoundTable.tsx
@@ -237,6 +237,16 @@ function DraggableSeat({
   const moved = useRef(false);
 
   const handlePointerDown = (e: PointerEventLike) => {
+    // Never arm a drag from an interactive child. A press on +/- that slides
+    // a few pixels (trackpad twitch, touch) would otherwise cross the slop
+    // threshold, capture the pointer away from the Pressable, and silently
+    // eat the tap — the life number just doesn't change, which players read
+    // as lag. Drag-reorder starts only from the tile's non-button surface.
+    // (react-native-web renders Pressable as role="button" in the DOM.)
+    const el = e.target as Element | null;
+    if (typeof el?.closest === 'function' && el.closest('[role="button"]')) {
+      return;
+    }
     // Record the origin but do NOT capture the pointer yet. Capturing here
     // redirects every later pointer event to this tile, so the +/- buttons
     // inside it never receive their pointerup and never fire a click.
@@ -304,6 +314,7 @@ function DraggableSeat({
 /** Minimal shape of the pointer events react-native-web forwards. */
 interface PointerEventLike {
   currentTarget: unknown;
+  target: unknown;
   nativeEvent: { clientX: number; clientY: number; pointerId: number };
 }
 


### PR DESCRIPTION
## The staging "lag" diagnosis

Staging felt laggier than prod when adjusting life. An A/B measurement (both bundles built locally, same emulator, 296 instrumented taps) showed **no latency regression**: tap→paint is ~3ms in both, the server echo never visibly moves the number, and even at 20x CPU throttle the new Round Table path is no slower than the old list.

The real mechanism: on the desktop Round Table (new since the prod build), every seat — including its +/- buttons — sits inside `DraggableSeat`'s pointer handlers. A press that slides **≥6px** before release (trackpad twitch, touch) crosses the drag slop, `setPointerCapture` retargets all subsequent events away from the Pressable, and `onPress` never fires. The tap is silently eaten: no error, no life change, tile jiggles and springs back. Players re-tap, and the gap between first press and eventual paint reads as lag. Prod's build has no Round Table, so the same sloppy click lands.

## Fix

`handlePointerDown` refuses to arm a drag when the press originates inside a `role="button"` descendant — drag-to-reorder now starts only from the tile's non-interactive surface (most of its area), so the feature is unchanged when grabbing tile chrome.

## Proof

New e2e case: press the +1 button, slide 8px, release.
- **Unfixed code: fails** (life never changes)
- **Fixed: passes**, and the slide is not read as a seat drag
- Full round-table spec: 4/4 locally against the emulator; typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)